### PR TITLE
feat: instrument NavigationRpcHandler

### DIFF
--- a/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService;
 
 import com.vaadin.extension.instrumentation.AfterNavigationStateRendererInstrumentation;
 import com.vaadin.extension.instrumentation.EventRpcHandlerInstrumentation;
+import com.vaadin.extension.instrumentation.NavigationRpcHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.UiInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
@@ -42,7 +43,8 @@ public class VaadinObservabilityInstrumentationModule extends InstrumentationMod
         return asList(
                 new AfterNavigationStateRendererInstrumentation(),
                 new UiInstrumentation(),
-                new EventRpcHandlerInstrumentation()
+                new EventRpcHandlerInstrumentation(),
+                new NavigationRpcHandlerInstrumentation()
         );
     }
 }

--- a/src/main/java/com/vaadin/extension/instrumentation/NavigationRpcHandlerInstrumentation.java
+++ b/src/main/java/com/vaadin/extension/instrumentation/NavigationRpcHandlerInstrumentation.java
@@ -1,0 +1,75 @@
+package com.vaadin.extension.instrumentation;
+
+import com.vaadin.extension.InstrumentationHelper;
+import com.vaadin.flow.server.communication.rpc.NavigationRpcHandler;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+/**
+ * Instruments NavigationRpcHandler in order to add a span when the handler is called
+ * with a navigation message from the client. This can be a router link navigation, or
+ * history navigation (back / forward button).
+ * This handler is only called when using the (deprecated) V14 bootstrap mode.
+ */
+public class NavigationRpcHandlerInstrumentation implements TypeInstrumentation {
+
+    @Override
+    public ElementMatcher<ClassLoader> classLoaderOptimization() {
+        return hasClassesNamed(
+                "com.vaadin.flow.server.communication.rpc.NavigationRpcHandler");
+    }
+
+    // This instrumentation only matches NavigationRpcHandler on the rpcEvent stack.
+    public ElementMatcher<TypeDescription> typeMatcher() {
+        return named(
+                "com.vaadin.flow.server.communication.rpc.NavigationRpcHandler");
+    }
+
+    public void transform(TypeTransformer transformer) {
+        transformer.applyAdviceToMethod(named("handle"),
+                this.getClass().getName() + "$MethodAdvice");
+    }
+
+    @SuppressWarnings("unused")
+    public static class MethodAdvice {
+        @Advice.OnMethodEnter()
+        public static void onEnter(@Advice.This NavigationRpcHandler navigationRpcHandler,
+                                   @Advice.Origin("#m") String methodName,
+                                   @Advice.Local("otelSpan") Span span) {
+
+            Tracer tracer = InstrumentationHelper.getTracer();
+
+            span = tracer.spanBuilder(
+                    navigationRpcHandler.getClass().getSimpleName() + "."
+                            + methodName).startSpan();
+        }
+
+        @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+        public static void onExit(
+                @Advice.Thrown
+                Throwable throwable,
+                @Advice.Local("otelSpan")
+                Span span) {
+            if (span == null) {
+                return;
+            }
+            if (throwable != null) {
+                // This will actually mark the span as having an exception which
+                // shows on the dataUI
+                span.setStatus(StatusCode.ERROR, throwable.getMessage());
+                // Add log trace of exception.
+                span.recordException(throwable);
+            }
+            span.end();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds instrumentation for `NavigationRpcHandler`. The handler seems to be only called for V14 apps, or when using the deprecated V14 bootstrap mode.

Did not add any additional attributes, as additional navigation info is available from the navigation instrumentation added here: #36 

Closes #13 