### PR TITLE
fix: clean up value changes for existing values

### DIFF
--- a/src/main/java/com/vaadin/extension/instrumentation/MapSyncRpcHandlerInstrumentation.java
+++ b/src/main/java/com/vaadin/extension/instrumentation/MapSyncRpcHandlerInstrumentation.java
@@ -62,6 +62,16 @@ public class MapSyncRpcHandlerInstrumentation implements TypeInstrumentation {
                     node);
             final Element element = elementInfo.getElement();
 
+            if (jsonObject.hasKey("property") && jsonObject.hasKey("value")) {
+                final String property = jsonObject.getString("property");
+                final String value = jsonObject.get("value").asString();
+                // skip if property or attribute is same
+                if (value.equals(element.getProperty(property, null))
+                        || value.equals(element.getAttribute(property))) {
+                    return;
+                }
+            }
+
             String spanName = "Sync: " + elementInfo.getElementLabel();
             span = InstrumentationHelper.startSpan(spanName);
             span.setAttribute("vaadin.element.tag", element.getTag());

--- a/src/test/java/com/vaadin/extension/instrumentation/MapSyncRpcHandlerInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/MapSyncRpcHandlerInstrumentationTest.java
@@ -26,7 +26,9 @@ class MapSyncRpcHandlerInstrumentationTest extends AbstractInstrumentationTest {
         component = new TestComponent();
         getMockUI().add(component);
         jsonObject = Json.createObject();
-        jsonObject.put("event", "click");
+        jsonObject.put("type", "mSync");
+        jsonObject.put("node", 128);
+        jsonObject.put("feature", 1);
     }
 
     @Test
@@ -60,6 +62,18 @@ class MapSyncRpcHandlerInstrumentationTest extends AbstractInstrumentationTest {
 
         SpanData span = getExportedSpan(0);
         this.assertSpanHasException(span, exception);
+    }
+
+    @Test
+    public void mapChange_existingValue_spanSkipped() {
+        jsonObject.put("property", "value");
+        jsonObject.put("value", "default");
+        component.getElement().setProperty("value", "default");
+
+        MapSyncRpcHandlerInstrumentation.MethodAdvice.onEnter(mapSyncRpcHandler,
+                "handleNode", component.getElement().getNode(), jsonObject,
+                null, null);
+        assertEquals(0, getCapturedSpanCount());
     }
 
     @Tag("test-component")


### PR DESCRIPTION
Do not generate a span for map events
that would set the same value to the property.
