### PR TITLE
feat: add session count metric

### DIFF
--- a/src/main/java/com/vaadin/extension/Metrics.java
+++ b/src/main/java/com/vaadin/extension/Metrics.java
@@ -1,0 +1,41 @@
+package com.vaadin.extension;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Metrics {
+    private static final AtomicBoolean registered = new AtomicBoolean();
+    private static final AtomicInteger sessionCount = new AtomicInteger();
+
+    public static void ensureMetricsRegistered() {
+        // Ensure meters are only created once
+        if (registered.compareAndSet(false, true)) {
+            Meter meter = GlobalOpenTelemetry
+                    .meterBuilder("com.vaadin.observability.instrumentation")
+                    .setInstrumentationVersion("1.0-alpha").build();
+
+            meter.gaugeBuilder("vaadin.session.count").ofLongs()
+                    .setDescription("Vaadin Session Count").setUnit("count")
+                    .buildWithCallback(measurement -> {
+                        measurement.record(sessionCount.get());
+                    });
+        }
+    }
+
+    public static int getSessionCount() {
+        return sessionCount.get();
+    }
+
+    public static void incrementSessionCount() {
+        Metrics.ensureMetricsRegistered();
+        sessionCount.incrementAndGet();
+    }
+
+    public static void decrementSessionCount() {
+        Metrics.ensureMetricsRegistered();
+        sessionCount.updateAndGet(value -> Math.max(0, value - 1));
+    }
+}

--- a/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -19,6 +19,7 @@ import com.vaadin.extension.instrumentation.StaticFileServerInstrumentation;
 import com.vaadin.extension.instrumentation.UidlRequestHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.UnsupportedBrowserHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.VaadinServiceInstrumentation;
+import com.vaadin.extension.instrumentation.VaadinSessionInstrumentation;
 import com.vaadin.extension.instrumentation.WebComponentProviderInstrumentation;
 import com.vaadin.extension.instrumentation.WebcomponentBootstrapHandlerInstrumentation;
 
@@ -77,7 +78,8 @@ public class VaadinObservabilityInstrumentationModule
                 new UidlRequestHandlerInstrumentation(),
                 new PwaHandlerInstrumentation(),
                 new UnsupportedBrowserHandlerInstrumentation(),
-                new ReturnChannelHandlerInstrumentation());
+                new ReturnChannelHandlerInstrumentation(),
+                new VaadinSessionInstrumentation());
         // @formatter:on
     }
 }

--- a/src/main/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentation.java
+++ b/src/main/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentation.java
@@ -1,0 +1,52 @@
+package com.vaadin.extension.instrumentation;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.vaadin.extension.Metrics;
+
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Instruments VaadinSession to keep track of the number of current sessions
+ */
+public class VaadinSessionInstrumentation implements TypeInstrumentation {
+
+    @Override
+    public ElementMatcher<ClassLoader> classLoaderOptimization() {
+        return hasClassesNamed("com.vaadin.flow.server.VaadinSession");
+    }
+
+    @Override
+    public ElementMatcher<TypeDescription> typeMatcher() {
+        return named("com.vaadin.flow.server.VaadinSession");
+    }
+
+    @Override
+    public void transform(TypeTransformer transformer) {
+        transformer.applyAdviceToMethod(named("valueBound"),
+                this.getClass().getName() + "$CreateSessionAdvice");
+        transformer.applyAdviceToMethod(named("valueUnbound"),
+                this.getClass().getName() + "$CloseSessionAdvice");
+    }
+
+    @SuppressWarnings("unused")
+    public static class CreateSessionAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void onEnter() {
+            Metrics.incrementSessionCount();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class CloseSessionAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void onEnter() {
+            Metrics.decrementSessionCount();
+        }
+    }
+}

--- a/src/test/java/com/vaadin/extension/instrumentation/MapSyncRpcHandlerInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/MapSyncRpcHandlerInstrumentationTest.java
@@ -8,22 +8,18 @@ import elemental.json.JsonObject;
 import com.vaadin.extension.conf.TraceLevel;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.server.communication.rpc.MapSyncRpcHandler;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class MapSyncRpcHandlerInstrumentationTest extends AbstractInstrumentationTest {
-    private MapSyncRpcHandler mapSyncRpcHandler;
     TestComponent component;
     JsonObject jsonObject;
 
     @BeforeEach
     public void setup() {
-        mapSyncRpcHandler = Mockito.mock(MapSyncRpcHandler.class);
         component = new TestComponent();
         getMockUI().add(component);
         jsonObject = Json.createObject();
@@ -69,9 +65,8 @@ class MapSyncRpcHandlerInstrumentationTest extends AbstractInstrumentationTest {
         jsonObject.put("value", "default");
         component.getElement().setProperty("value", "default");
 
-        MapSyncRpcHandlerInstrumentation.MethodAdvice.onEnter(mapSyncRpcHandler,
-                "handleNode", component.getElement().getNode(), jsonObject,
-                null, null);
+        MapSyncRpcHandlerInstrumentation.MethodAdvice.onEnter(
+                component.getElement().getNode(), jsonObject, null, null);
         assertEquals(0, getCapturedSpanCount());
     }
 

--- a/src/test/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentationTest.java
@@ -1,0 +1,31 @@
+package com.vaadin.extension.instrumentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.vaadin.extension.Metrics;
+
+import org.junit.jupiter.api.Test;
+
+class VaadinSessionInstrumentationTest {
+
+    @Test
+    public void increaseAndDecreaseSessionCount() {
+        VaadinSessionInstrumentation.CreateSessionAdvice.onEnter();
+        VaadinSessionInstrumentation.CreateSessionAdvice.onEnter();
+        VaadinSessionInstrumentation.CreateSessionAdvice.onEnter();
+
+        assertEquals(3, Metrics.getSessionCount());
+
+        VaadinSessionInstrumentation.CloseSessionAdvice.onEnter();
+        VaadinSessionInstrumentation.CloseSessionAdvice.onEnter();
+
+        assertEquals(1, Metrics.getSessionCount());
+
+        // Should not go below 0
+        VaadinSessionInstrumentation.CloseSessionAdvice.onEnter();
+        VaadinSessionInstrumentation.CloseSessionAdvice.onEnter();
+        VaadinSessionInstrumentation.CloseSessionAdvice.onEnter();
+
+        assertEquals(0, Metrics.getSessionCount());
+    }
+}


### PR DESCRIPTION
## Description

Adds a metric for the Vaadin session count. The metric uses a gauge measurement, which automatically reports a specific value in intervals. This uses the Vaadin session count specifically, rather than HTTP sessions, I figure this is appropriate for what we want.

Closes #78 
