### PR TITLE
feat: add ui count metric

### DIFF
--- a/src/main/java/com/vaadin/extension/Metrics.java
+++ b/src/main/java/com/vaadin/extension/Metrics.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class Metrics {
     private static final AtomicBoolean registered = new AtomicBoolean();
     private static final AtomicInteger sessionCount = new AtomicInteger();
+    private static final AtomicInteger uiCount = new AtomicInteger();
 
     public static void ensureMetricsRegistered() {
         // Ensure meters are only created once
@@ -22,11 +23,21 @@ public class Metrics {
                     .buildWithCallback(measurement -> {
                         measurement.record(sessionCount.get());
                     });
+
+            meter.gaugeBuilder("vaadin.ui.count").ofLongs()
+                    .setDescription("Vaadin UI Count").setUnit("count")
+                    .buildWithCallback(measurement -> {
+                        measurement.record(uiCount.get());
+                    });
         }
     }
 
     public static int getSessionCount() {
         return sessionCount.get();
+    }
+
+    public static int getUiCount() {
+        return uiCount.get();
     }
 
     public static void incrementSessionCount() {
@@ -37,5 +48,15 @@ public class Metrics {
     public static void decrementSessionCount() {
         Metrics.ensureMetricsRegistered();
         sessionCount.updateAndGet(value -> Math.max(0, value - 1));
+    }
+
+    public static void incrementUiCount() {
+        Metrics.ensureMetricsRegistered();
+        uiCount.incrementAndGet();
+    }
+
+    public static void decrementUiCount() {
+        Metrics.ensureMetricsRegistered();
+        uiCount.updateAndGet(value -> Math.max(0, value - 1));
     }
 }

--- a/src/main/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentation.java
+++ b/src/main/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentation.java
@@ -12,7 +12,8 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /**
- * Instruments VaadinSession to keep track of the number of current sessions
+ * Instruments VaadinSession to keep track of the number of current sessions and
+ * UIs
  */
 public class VaadinSessionInstrumentation implements TypeInstrumentation {
 
@@ -32,6 +33,11 @@ public class VaadinSessionInstrumentation implements TypeInstrumentation {
                 this.getClass().getName() + "$CreateSessionAdvice");
         transformer.applyAdviceToMethod(named("valueUnbound"),
                 this.getClass().getName() + "$CloseSessionAdvice");
+
+        transformer.applyAdviceToMethod(named("addUI"),
+                this.getClass().getName() + "$AddUiAdvice");
+        transformer.applyAdviceToMethod(named("removeUI"),
+                this.getClass().getName() + "$RemoveUiAdvice");
     }
 
     @SuppressWarnings("unused")
@@ -47,6 +53,22 @@ public class VaadinSessionInstrumentation implements TypeInstrumentation {
         @Advice.OnMethodEnter(suppress = Throwable.class)
         public static void onEnter() {
             Metrics.decrementSessionCount();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class AddUiAdvice {
+        @Advice.OnMethodExit(suppress = Throwable.class)
+        public static void onExit() {
+            Metrics.incrementUiCount();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class RemoveUiAdvice {
+        @Advice.OnMethodExit(suppress = Throwable.class)
+        public static void onExit() {
+            Metrics.decrementUiCount();
         }
     }
 }

--- a/src/test/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/VaadinSessionInstrumentationTest.java
@@ -28,4 +28,25 @@ class VaadinSessionInstrumentationTest {
 
         assertEquals(0, Metrics.getSessionCount());
     }
+
+    @Test
+    public void increaseAndDecreaseUiCount() {
+        VaadinSessionInstrumentation.AddUiAdvice.onExit();
+        VaadinSessionInstrumentation.AddUiAdvice.onExit();
+        VaadinSessionInstrumentation.AddUiAdvice.onExit();
+
+        assertEquals(3, Metrics.getUiCount());
+
+        VaadinSessionInstrumentation.RemoveUiAdvice.onExit();
+        VaadinSessionInstrumentation.RemoveUiAdvice.onExit();
+
+        assertEquals(1, Metrics.getUiCount());
+
+        // Should not go below 0
+        VaadinSessionInstrumentation.RemoveUiAdvice.onExit();
+        VaadinSessionInstrumentation.RemoveUiAdvice.onExit();
+        VaadinSessionInstrumentation.RemoveUiAdvice.onExit();
+
+        assertEquals(0, Metrics.getUiCount());
+    }
 }


### PR DESCRIPTION
## Description

Adds a metric for the Vaadin UI count. The metric uses a gauge measurement, which automatically reports a specific value in intervals.

Closes #73 