### PR TITLE
refactor: mark root span as server span

### DIFF
--- a/src/main/java/com/vaadin/extension/Constants.java
+++ b/src/main/java/com/vaadin/extension/Constants.java
@@ -8,7 +8,6 @@ public class Constants {
     public static final String CONFIG_TRACE_LEVEL = "otel.instrumentation.vaadin.trace-level";
 
     // Vaadin attribute names
-    public static final String HTTP_TARGET = "http.target";
     public static final String SESSION_ID = "vaadin.session.id";
     public static final String REQUEST_TYPE = "vaadin.request.type";
 }

--- a/src/main/java/com/vaadin/extension/InstrumentationRequest.java
+++ b/src/main/java/com/vaadin/extension/InstrumentationRequest.java
@@ -1,23 +1,32 @@
 package com.vaadin.extension;
 
+import io.opentelemetry.api.trace.SpanKind;
+
 import java.util.Collections;
 import java.util.Map;
 
 public class InstrumentationRequest {
-    private String name;
-    private Map<String, String> attributes;
+    private final String name;
+    private final SpanKind spanKind;
+    private final Map<String, String> attributes;
 
-    public InstrumentationRequest(String name) {
-        this(name, Collections.emptyMap());
+    public InstrumentationRequest(String name, SpanKind spanKind) {
+        this(name, spanKind, Collections.emptyMap());
     }
 
-    public InstrumentationRequest(String name, Map<String, String> attributes) {
+    public InstrumentationRequest(String name, SpanKind spanKind,
+            Map<String, String> attributes) {
         this.name = name;
+        this.spanKind = spanKind;
         this.attributes = attributes;
     }
 
     public String getName() {
         return name;
+    }
+
+    public SpanKind getSpanKind() {
+        return spanKind;
     }
 
     public Map<String, String> getAttributes() {

--- a/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
+++ b/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
@@ -1,0 +1,34 @@
+package com.vaadin.extension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+class InstrumentationHelperTest extends AbstractInstrumentationTest {
+
+    @Test
+    public void handleException() {
+        Exception exception = new RuntimeException("Something went wrong");
+        try (var ignored = withRootContext()) {
+            Span span = InstrumentationHelper.startSpan("Test span");
+            InstrumentationHelper.handleException(span, exception);
+            span.end();
+        }
+
+        // Should record exception as event on span
+        SpanData testSpan = getExportedSpan(0);
+        assertEquals("Test span", testSpan.getName());
+        assertSpanHasException(testSpan, exception);
+
+        // Should mark root span as error
+        SpanData rootSpan = getExportedSpan(1);
+        assertEquals(StatusCode.ERROR, rootSpan.getStatus().getStatusCode());
+        assertEquals("java.lang.RuntimeException: Something went wrong",
+                rootSpan.getStatus().getDescription());
+    }
+}


### PR DESCRIPTION
## Description

Changes the `VaadinServiceInstrumentation` to mark the root spans it creates as server spans instead of internal ones, and marks the root span as having an error if a nested exception occurs. This is necessary to have several vendors (New Relic, DataDog, Dynatrace) include the spans in their error monitoring.
Also adds several HTTP semantic attributes that we lost from disabling the default HTTP request instrumentations.

