### PR TITLE
feat: use label as possible element identifier

### DIFF
--- a/src/main/java/com/vaadin/extension/ElementInstrumentationInfo.java
+++ b/src/main/java/com/vaadin/extension/ElementInstrumentationInfo.java
@@ -2,6 +2,7 @@ package com.vaadin.extension;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.StateNode;
@@ -74,7 +75,7 @@ public class ElementInstrumentationInfo {
 
     /**
      * Get the most informative identifier for the handled element.
-     * 
+     *
      * @return most informative identifier
      */
     private String getIdentifier() {
@@ -84,6 +85,10 @@ public class ElementInstrumentationInfo {
         if (component.isPresent() && component.get().getId().isPresent()) {
             identifier = String.format("[id='%s']",
                     component.get().getId().get());
+        } else if (component.isPresent() && component.get() instanceof HasLabel
+                && ((HasLabel) component.get()).getLabel() != null) {
+            identifier = String.format("[label='%s']",
+                    ((HasLabel) component.get()).getLabel());
         } else if (element.getText() != null && !element.getText().isEmpty()) {
             identifier = String.format("[%s]", element.getText());
         }

--- a/src/test/java/com/vaadin/extension/ElementInstrumentationInfoTest.java
+++ b/src/test/java/com/vaadin/extension/ElementInstrumentationInfoTest.java
@@ -1,0 +1,61 @@
+package com.vaadin.extension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasLabel;
+import com.vaadin.flow.component.HasText;
+import com.vaadin.flow.component.Tag;
+
+import org.junit.jupiter.api.Test;
+
+class ElementInstrumentationInfoTest {
+
+    @Test
+    public void elementLabel_withId() {
+        TestComponent component = new TestComponent();
+        component.setId("test-id");
+        component.setLabel("test-label");
+        component.setText("test-text");
+
+        ElementInstrumentationInfo info = new ElementInstrumentationInfo(
+                component.getElement().getNode());
+        assertEquals("test-component[id='test-id']", info.getElementLabel());
+    }
+
+    @Test
+    public void getIdentifier_withLabel() {
+        TestComponent component = new TestComponent();
+        component.setLabel("test-label");
+        component.setText("test-text");
+
+        ElementInstrumentationInfo info = new ElementInstrumentationInfo(
+                component.getElement().getNode());
+        assertEquals("test-component[label='test-label']",
+                info.getElementLabel());
+    }
+
+    @Test
+    public void getIdentifier_withText() {
+        TestComponent component = new TestComponent();
+        component.setText("test-text");
+
+        ElementInstrumentationInfo info = new ElementInstrumentationInfo(
+                component.getElement().getNode());
+        assertEquals("test-component[test-text]", info.getElementLabel());
+    }
+
+    @Test
+    public void getIdentifier_withTagName() {
+        TestComponent component = new TestComponent();
+
+        ElementInstrumentationInfo info = new ElementInstrumentationInfo(
+                component.getElement().getNode());
+        assertEquals("test-component", info.getElementLabel());
+    }
+
+    @Tag("test-component")
+    private static class TestComponent extends Component
+            implements HasLabel, HasText {
+    }
+}


### PR DESCRIPTION
## Description

Extends `ElementInstrumentationInfo` logic to use the component's label as identifier if the component implements `HasLabel`.

Part of #38 