### PR TITLE
feat: instrument DataCommunicator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 
   implementation enforcedPlatform("com.vaadin:vaadin-bom:${vaadinVersion}")
   compileOnly("com.vaadin:flow-server")
+  compileOnly("com.vaadin:flow-data")
 //  implementation 'com.vaadin:license-checker'
 
   //Provides @AutoService annotation that makes registration of our SPI implementations much easier
@@ -96,6 +97,7 @@ dependencies {
 
   //All dependencies below are only for tests
   testImplementation("com.vaadin:flow-server")
+  testImplementation("com.vaadin:flow-data")
   testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:${versions.opentelemetryJavaagentAlpha}")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
   testImplementation("org.mockito:mockito-inline:${versions.mockito}")

--- a/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -4,6 +4,7 @@ import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.
 import static java.util.Arrays.asList;
 
 import com.vaadin.extension.instrumentation.AfterNavigationStateRendererInstrumentation;
+import com.vaadin.extension.instrumentation.DataCommunicatorInstrumentation;
 import com.vaadin.extension.instrumentation.communication.HeartbeatHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.communication.JavaScriptBootstrapHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.communication.PwaHandlerInstrumentation;
@@ -84,7 +85,9 @@ public class VaadinObservabilityInstrumentationModule
                 new PwaHandlerInstrumentation(),
                 new UnsupportedBrowserHandlerInstrumentation(),
                 new ReturnChannelHandlerInstrumentation(),
-                new VaadinSessionInstrumentation());
+                new VaadinSessionInstrumentation(),
+                new DataCommunicatorInstrumentation()
+        );
         // @formatter:on
     }
 }

--- a/src/main/java/com/vaadin/extension/instrumentation/DataCommunicatorInstrumentation.java
+++ b/src/main/java/com/vaadin/extension/instrumentation/DataCommunicatorInstrumentation.java
@@ -1,0 +1,61 @@
+package com.vaadin.extension.instrumentation;
+
+import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import com.vaadin.extension.InstrumentationHelper;
+import com.vaadin.flow.data.provider.DataCommunicator;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Instruments DataCommunicator to add a span for the duration of data provider
+ * fetches
+ */
+public class DataCommunicatorInstrumentation implements TypeInstrumentation {
+
+    @Override
+    public ElementMatcher<TypeDescription> typeMatcher() {
+        return named("com.vaadin.flow.data.provider.DataCommunicator");
+    }
+
+    @Override
+    public void transform(TypeTransformer transformer) {
+        transformer.applyAdviceToMethod(named("fetchFromProvider"),
+                this.getClass().getName() + "$FetchAdvice");
+    }
+
+    @SuppressWarnings("unused")
+    public static class FetchAdvice {
+
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void onEnter(
+                @Advice.This DataCommunicator dataCommunicator,
+                @Advice.Argument(0) int offset, @Advice.Argument(1) int limit,
+                @Advice.Local("otelSpan") Span span,
+                @Advice.Local("otelScope") Scope scope) {
+            span = InstrumentationHelper.startSpan("Data Provider Fetch");
+            span.setAttribute("vaadin.dataprovider.type", dataCommunicator
+                    .getDataProvider().getClass().getCanonicalName());
+            span.setAttribute("vaadin.dataprovider.limit", limit);
+            span.setAttribute("vaadin.dataprovider.offset", offset);
+
+            Context context = currentContext().with(span);
+            scope = context.makeCurrent();
+        }
+
+        @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+        public static void onExit(@Advice.Thrown Throwable throwable,
+                @Advice.Local("otelSpan") Span span,
+                @Advice.Local("otelScope") Scope scope) {
+            InstrumentationHelper.endSpan(span, throwable, scope);
+        }
+    }
+}

--- a/src/test/java/com/vaadin/extension/instrumentation/DataCommunicatorInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/DataCommunicatorInstrumentationTest.java
@@ -1,0 +1,39 @@
+package com.vaadin.extension.instrumentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.vaadin.flow.data.provider.DataCommunicator;
+import com.vaadin.flow.data.provider.DataProvider;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DataCommunicatorInstrumentationTest extends AbstractInstrumentationTest {
+    @Test
+    public void fetchFromDataProvider_createsSpan() {
+        DataProvider dataProvider = Mockito.mock(DataProvider.class);
+        DataCommunicator dataCommunicator = Mockito
+                .mock(DataCommunicator.class);
+        Mockito.when(dataCommunicator.getDataProvider())
+                .thenReturn(dataProvider);
+
+        DataCommunicatorInstrumentation.FetchAdvice.onEnter(dataCommunicator,
+                100, 50, null, null);
+        DataCommunicatorInstrumentation.FetchAdvice.onExit(null,
+                getCapturedSpan(0), null);
+
+        SpanData span = getExportedSpan(0);
+        assertEquals("Data Provider Fetch", span.getName());
+        String dataProviderType = span.getAttributes()
+                .get(AttributeKey.stringKey("vaadin.dataprovider.type"));
+        assertNotNull(dataProviderType);
+        assertTrue(dataProviderType
+                .startsWith("com.vaadin.flow.data.provider.DataProvider"));
+        assertEquals(100, span.getAttributes()
+                .get(AttributeKey.longKey("vaadin.dataprovider.offset")));
+        assertEquals(50, span.getAttributes()
+                .get(AttributeKey.longKey("vaadin.dataprovider.limit")));
+    }
+}


### PR DESCRIPTION
Instruments `DataCommunicator` to add a span for every time the data communicator fetches data from a data provider.

This does not cover `HierarchicalDataCommunicator` at the moment.
