### PR TITLE
fix: make navigation span show target route

### DIFF
--- a/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -3,7 +3,7 @@ package com.vaadin.extension;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
-import com.vaadin.extension.instrumentation.AfterNavigationStateRendererInstrumentation;
+import com.vaadin.extension.instrumentation.AbstractNavigationStateRendererInstrumentation;
 import com.vaadin.extension.instrumentation.DataCommunicatorInstrumentation;
 import com.vaadin.extension.instrumentation.communication.HeartbeatHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.communication.JavaScriptBootstrapHandlerInstrumentation;
@@ -69,7 +69,7 @@ public class VaadinObservabilityInstrumentationModule
                 new AttachTemplateChildRpcHandlerInstrumentation(),
                 new WebcomponentBootstrapHandlerInstrumentation(),
                 new WebComponentProviderInstrumentation(),
-                new AfterNavigationStateRendererInstrumentation(),
+                new AbstractNavigationStateRendererInstrumentation(),
                 new StreamRequestHandlerInstrumentation(),
                 new EventRpcHandlerInstrumentation(),
                 new NavigationRpcHandlerInstrumentation(),

--- a/src/main/java/com/vaadin/extension/instrumentation/AbstractNavigationStateRendererInstrumentation.java
+++ b/src/main/java/com/vaadin/extension/instrumentation/AbstractNavigationStateRendererInstrumentation.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  * initiated from. Also adds a nested span with more information about the
  * navigation operation.
  */
-public class AfterNavigationStateRendererInstrumentation
+public class AbstractNavigationStateRendererInstrumentation
         implements TypeInstrumentation {
 
     @Override
@@ -46,20 +46,10 @@ public class AfterNavigationStateRendererInstrumentation
                 @Advice.Local("otelSpan") Span span,
                 @Advice.Local("otelScope") Scope scope) {
             span = InstrumentationHelper.startSpan("Navigate");
-
-            Context context = currentContext().with(span);
-            scope = context.makeCurrent();
-        }
-
-        @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-        public static void onExit(@Advice.Thrown Throwable throwable,
-                @Advice.Argument(0) NavigationEvent event,
-                @Advice.Local("otelSpan") Span span,
-                @Advice.Local("otelScope") Scope scope) {
-            // Seems UI only contains the correct route after the method
-            // finishes, so this needs to run on exit
+            String path = event.getLocation().getPath();
             Optional<String> routeTemplate = InstrumentationHelper
-                    .getActiveRouteTemplate(event.getUI());
+                    .getRouteTemplateForLocation(path);
+
             if (routeTemplate.isPresent()) {
                 String route = "/" + routeTemplate.get();
                 span.updateName(String.format("Navigate: %s", route));
@@ -70,6 +60,15 @@ public class AfterNavigationStateRendererInstrumentation
             span.setAttribute("vaadin.navigation.trigger",
                     event.getTrigger().name());
 
+            Context context = currentContext().with(span);
+            scope = context.makeCurrent();
+        }
+
+        @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+        public static void onExit(@Advice.Thrown Throwable throwable,
+                @Advice.Argument(0) NavigationEvent event,
+                @Advice.Local("otelSpan") Span span,
+                @Advice.Local("otelScope") Scope scope) {
             InstrumentationHelper.endSpan(span, throwable, scope);
             // Update route after navigation to display the new route
             InstrumentationHelper.updateHttpRoute(event.getUI());

--- a/src/test/java/com/vaadin/extension/instrumentation/AbstractNavigationStateRendererInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/AbstractNavigationStateRendererInstrumentationTest.java
@@ -1,0 +1,73 @@
+package com.vaadin.extension.instrumentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.NavigationEvent;
+import com.vaadin.flow.router.NavigationTrigger;
+import com.vaadin.flow.router.RouteConfiguration;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+class AbstractNavigationStateRendererInstrumentationTest
+        extends AbstractInstrumentationTest {
+
+    private NavigationEvent navigationEvent;
+
+    @BeforeEach
+    public void setup() {
+        RouteConfiguration.forSessionScope().setRoute("new-route",
+                NewRouteView.class);
+
+        Location location = new Location("new-route");
+        navigationEvent = Mockito.mock(NavigationEvent.class);
+        Mockito.when(navigationEvent.getLocation()).thenReturn(location);
+        Mockito.when(navigationEvent.getTrigger())
+                .thenReturn(NavigationTrigger.CLIENT_SIDE);
+        Mockito.when(navigationEvent.isForwardTo()).thenReturn(true);
+        Mockito.when(navigationEvent.getUI()).thenReturn(getMockUI());
+    }
+
+    @Test
+    public void handle_createsSpan() {
+        AbstractNavigationStateRendererInstrumentation.HandleAdvice
+                .onEnter(navigationEvent, null, null);
+        AbstractNavigationStateRendererInstrumentation.HandleAdvice.onExit(null,
+                navigationEvent, getCapturedSpan(0), null);
+
+        SpanData span = getExportedSpan(0);
+        assertEquals("Navigate: /new-route", span.getName());
+        assertEquals("CLIENT_SIDE", span.getAttributes()
+                .get(AttributeKey.stringKey("vaadin.navigation.trigger")));
+        assertEquals(true, span.getAttributes()
+                .get(AttributeKey.booleanKey("vaadin.navigation.isForwardTo")));
+    }
+
+    @Test
+    public void handle_updatesRootSpan() {
+        getMockUI().getInternals().showRouteTarget(new Location("new-route"),
+                new NewRouteView(), new ArrayList<>());
+
+        try (var ignored = withRootContext()) {
+            AbstractNavigationStateRendererInstrumentation.HandleAdvice
+                    .onEnter(navigationEvent, null, null);
+            AbstractNavigationStateRendererInstrumentation.HandleAdvice
+                    .onExit(null, navigationEvent, getCapturedSpan(0), null);
+        }
+
+        SpanData span = getExportedSpan(1);
+        assertEquals("/new-route", span.getName());
+    }
+
+    @Tag("new-route")
+    protected static class NewRouteView extends Component {
+    }
+}


### PR DESCRIPTION
Fixes the `AbstractNavigationStateRendererInstrumentation` to show the route that navigation was attempted to, instead of the route that the UI has after navigation. The UI route might not have changed if an error occurs or the navigation is postponed.

The root span still shows the route that the UI had after the navigation as it would not be correct to update it if the navigation was postponed.

Fixes #94