### PR TITLE
feat: add LicenseCheck to project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   implementation enforcedPlatform("com.vaadin:vaadin-bom:${vaadinVersion}")
   compileOnly("com.vaadin:flow-server")
   compileOnly("com.vaadin:flow-data")
-//  implementation 'com.vaadin:license-checker'
+  implementation('com.vaadin:license-checker')
 
   //Provides @AutoService annotation that makes registration of our SPI implementations much easier
   compileOnly deps.autoservice

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-vaadinVersion=23.1.6
+vaadinVersion=23.1.8
 projectVersion=1.0-SNAPSHOT
 projectName=opentelemetry-vaadin-observability-instrumentation-extension
 # workaround for https://github.com/diffplug/spotless/issues/834

--- a/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -1,5 +1,6 @@
 package com.vaadin.extension;
 
+import static com.vaadin.extension.InstrumentationHelper.INSTRUMENTATION_VERSION;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 import static java.util.Arrays.asList;
 
@@ -25,6 +26,8 @@ import com.vaadin.extension.instrumentation.server.ErrorHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.server.StaticFileServerInstrumentation;
 import com.vaadin.extension.instrumentation.server.VaadinServiceInstrumentation;
 import com.vaadin.extension.instrumentation.server.VaadinSessionInstrumentation;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -36,6 +39,12 @@ import java.util.List;
 @AutoService(InstrumentationModule.class)
 public class VaadinObservabilityInstrumentationModule
         extends InstrumentationModule {
+
+    static {
+        LicenseChecker.checkLicenseFromStaticBlock("vaadin-observability",
+                INSTRUMENTATION_VERSION, BuildType.PRODUCTION);
+    }
+
     // The instrumentation names should reflect what is in `settings.gradle`
     // `rootProject.name`
     public static final String INSTRUMENTATION_NAME = "vaadin-observability";


### PR DESCRIPTION
Add LicenseChecking to project.
License will be check on runtime when
starting the JavaAgent.

Closes #107
