### PR TITLE
feat: add sync property name

### DIFF
--- a/src/main/java/com/vaadin/extension/instrumentation/communication/rpc/MapSyncRpcHandlerInstrumentation.java
+++ b/src/main/java/com/vaadin/extension/instrumentation/communication/rpc/MapSyncRpcHandlerInstrumentation.java
@@ -64,8 +64,9 @@ public class MapSyncRpcHandlerInstrumentation implements TypeInstrumentation {
                     node);
             final Element element = elementInfo.getElement();
 
+            String property = null;
             if (jsonObject.hasKey("property") && jsonObject.hasKey("value")) {
-                final String property = jsonObject.getString("property");
+                property = jsonObject.getString("property");
                 final String value = jsonObject.get("value").asString();
                 // skip if property or attribute is same
                 if (value.equals(element.getProperty(property, null))
@@ -75,8 +76,14 @@ public class MapSyncRpcHandlerInstrumentation implements TypeInstrumentation {
             }
 
             String spanName = "Sync: " + elementInfo.getElementLabel();
+            if (property != null) {
+                spanName += "." + property;
+            }
             span = InstrumentationHelper.startSpan(spanName);
             span.setAttribute("vaadin.element.tag", element.getTag());
+            if (property != null) {
+                span.setAttribute("vaadin.element.property", property);
+            }
             // If possible add active view class name as an attribute to the
             // span
             if (elementInfo.getViewLabel() != null) {

--- a/src/test/java/com/vaadin/extension/instrumentation/communication/rpc/MapSyncRpcHandlerInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/communication/rpc/MapSyncRpcHandlerInstrumentationTest.java
@@ -28,6 +28,8 @@ class MapSyncRpcHandlerInstrumentationTest extends AbstractInstrumentationTest {
         jsonObject.put("type", "mSync");
         jsonObject.put("node", 128);
         jsonObject.put("feature", 1);
+        jsonObject.put("property", "value");
+        jsonObject.put("value", "foo");
     }
 
     @Test
@@ -40,9 +42,11 @@ class MapSyncRpcHandlerInstrumentationTest extends AbstractInstrumentationTest {
                 getCapturedSpan(0), null);
 
         SpanData span = getExportedSpan(0);
-        assertEquals("Sync: test-component[foo]", span.getName());
+        assertEquals("Sync: test-component[foo].value", span.getName());
         assertEquals("test-component", span.getAttributes()
                 .get(AttributeKey.stringKey("vaadin.element.tag")));
+        assertEquals("value", span.getAttributes()
+                .get(AttributeKey.stringKey("vaadin.element.property")));
         assertEquals("TestView", span.getAttributes()
                 .get(AttributeKey.stringKey("vaadin.view")));
         assertEquals(getMockSessionId(),


### PR DESCRIPTION
Adds the synced property name to the `MapSyncRpcHandlerInstrumentation`

