### PR TITLE
fix: remove dynamic parts from root span name

### DIFF
--- a/src/test/java/com/vaadin/extension/instrumentation/communication/StreamRequestHandlerInstrumentationTest.java
+++ b/src/test/java/com/vaadin/extension/instrumentation/communication/StreamRequestHandlerInstrumentationTest.java
@@ -6,6 +6,7 @@ import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
 import com.vaadin.flow.server.VaadinRequest;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -34,7 +35,7 @@ public class StreamRequestHandlerInstrumentationTest
     public void handleRequest_mainSpanIsUpdated() {
         final VaadinRequest request = Mockito.mock(VaadinRequest.class);
 
-        final String fileName = "/VAADIN/dynamic/resource/0/aa284e2/file";
+        final String fileName = "/dynamic/resource/0/aa284e2/image.png";
         Mockito.when(request.getPathInfo()).thenReturn(fileName);
 
         try (var ignored = withRootContext()) {
@@ -45,8 +46,13 @@ public class StreamRequestHandlerInstrumentationTest
         }
 
         assertEquals("Handle dynamic file", getExportedSpan(0).getName());
-        assertEquals("/VAADIN/dynamic/resource/[UIID]/[SECKEY]/file",
+        assertEquals("/dynamic/resource/[ui]/[secret]/image.png",
                 getExportedSpan(1).getName());
+        assertEquals("/dynamic/resource/[ui]/[secret]/image.png",
+                getExportedSpan(1).getAttributes()
+                        .get(SemanticAttributes.HTTP_ROUTE));
+        assertEquals("/dynamic/resource/0/aa284e2/image.png", getExportedSpan(1)
+                .getAttributes().get(SemanticAttributes.HTTP_TARGET));
     }
 
     @Test


### PR DESCRIPTION
## Description

The logic in `StreamResourceHandlerInstrumentation` for removing the parametrized URL parts does not work properly ATM:

![Bildschirmfoto 2022-09-15 um 14 41 05](https://user-images.githubusercontent.com/357820/190406329-7868a38e-57c5-4db1-9a04-5d8f05884a1d.png)

This changes the logic to generate a new path based on the filename instead of trying to fix the existing one. That might not be 100% in all cases, but it's consistent, and users probably don't care that much about the actual URL. This also sets the `http.route` to the generalized URL, and `http.target` to the actual path.

![Bildschirmfoto 2022-09-15 um 14 26 12](https://user-images.githubusercontent.com/357820/190406946-6929939e-9941-491e-a47e-9b380cdee22b.png)

