### PR TITLE
fix: re-enable http-client instrumentations

### DIFF
--- a/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
+++ b/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
@@ -66,12 +66,8 @@ public class ConfigurationDefaults
         // Set the service name to vaadin by default.
         addProperty(properties, "otel.service.name", "vaadin", defaultconfig);
 
-        addProperty(properties, "otel.instrumentation.java-http-client.enabled",
-                "false", defaultconfig);
         addProperty(properties, "otel.instrumentation.jetty.enabled", "false",
                 defaultconfig);
-        addProperty(properties, "otel.instrumentation.jetty-httpclient.enabled",
-                "false", defaultconfig);
         addProperty(properties, "otel.instrumentation.servlet.enabled", "false",
                 defaultconfig);
         addProperty(properties, "otel.instrumentation.tomcat.enabled", "false",


### PR DESCRIPTION
The http-client instrumentations' purpose seems to be to instrument classes that are used for outgoing HTTP requests, rather than incoming ones. By disabling them we likely break the distributed tracing feature of OpenTelemetry, as they will not be able to set trace and parent ID on outgoing requests. Let's restore them.

`java-http-client`

> An HttpClient can be used to send requests and retrieve their responses. An HttpClient is created through a builder. The builder can be used to configure per-client state, like: the preferred protocol version ( HTTP/1.1 or HTTP/2 ), whether to follow redirects, a proxy, an authenticator, etc. Once built, an HttpClient is immutable, and can be used to send multiple requests.

`jetty-http-client`

> HttpClient provides an efficient, asynchronous, non-blocking implementation to perform HTTP requests to a server through a simple API that offers also blocking semantic.
  HttpClient provides easy-to-use methods such as GET(String) that allow to perform HTTP requests in a one-liner, but also gives the ability to fine tune the configuration of requests via newRequest(URI).