### PR TITLE
Fix formatting of VaadinObservabilityInstrumentationModule.java

### DIFF
--- a/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -51,7 +51,8 @@ public class VaadinObservabilityInstrumentationModule
     // The instrumentation names should reflect what is in `settings.gradle`
     // `rootProject.name`
     public static final String INSTRUMENTATION_NAME = "vaadin-observability-kit";
-    public static final String EXTENDED_NAME = "opentelemetry-vaadin-observability-instrumentation-extension-" + INSTRUMENTATION_VERSION;
+    public static final String EXTENDED_NAME = "opentelemetry-vaadin-observability-instrumentation-extension-"
+            + INSTRUMENTATION_VERSION;
 
     public VaadinObservabilityInstrumentationModule() {
         super(INSTRUMENTATION_NAME, EXTENDED_NAME);


### PR DESCRIPTION
## Description

A rerun of the `spotlessApply` Gradle target resulted in a small formatting change for the `VaadinObservabilityInstrumentationModule.java` file.