### PR TITLE
chore: Update vaadin-parent to 2.1.0

### DIFF
--- a/deploy.xml
+++ b/deploy.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.5</version>
+        <version>2.1.0</version>
     </parent>
 
     <groupId>com.vaadin.observability</groupId>


### PR DESCRIPTION
Updates `vaadin-parent` to `2.1.0` which has JDK 17 support.