### PR TITLE
Use Flow version instead of platform

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ ext {
 repositories {
   mavenCentral()
   maven {
+    name = "vaadin-prereleases"
+    url = uri("https://maven.vaadin.com/vaadin-prereleases/")
+  }
+  maven {
     name = "sonatype"
     url = uri("https://oss.sonatype.org/content/repositories/snapshots")
   }
@@ -70,10 +74,9 @@ dependencies {
   compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:${versions.opentelemetryJavaagentAlpha}")
   compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
 
-  implementation enforcedPlatform("com.vaadin:vaadin-bom:${vaadinVersion}")
-  compileOnly("com.vaadin:flow-server")
-  compileOnly("com.vaadin:flow-data")
-  implementation('com.vaadin:license-checker')
+  compileOnly("com.vaadin:flow-server:${flowVersion}")
+  compileOnly("com.vaadin:flow-data:${flowVersion}")
+  implementation('com.vaadin:license-checker:1.11.2')
 
   //Provides @AutoService annotation that makes registration of our SPI implementations much easier
   compileOnly deps.autoservice
@@ -97,8 +100,8 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3:3.11'
 
   //All dependencies below are only for tests
-  testImplementation("com.vaadin:flow-server")
-  testImplementation("com.vaadin:flow-data")
+  testImplementation("com.vaadin:flow-server:${flowVersion}")
+  testImplementation("com.vaadin:flow-data:${flowVersion}")
   testImplementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:${versions.opentelemetryJavaagentAlpha}")
   testImplementation("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
   testImplementation("org.mockito:mockito-inline:${versions.mockito}")

--- a/deploy.xml
+++ b/deploy.xml
@@ -31,7 +31,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <gradle.executable>./gradlew</gradle.executable>
-        <vaadin.version>23.2.0</vaadin.version>
+        <flow.version>23.3-SNAPSHOT</flow.version>
     </properties>
 
     <build>
@@ -52,7 +52,7 @@
                                 <argument>build</argument>
                                 <argument>extendedAgent</argument>
                                 <argument>-PprojectVersion=${project.version}</argument>
-                                <argument>-PvaadinVersion=${vaadin.version}</argument>
+                                <argument>-PflowVersion=${flow.version}</argument>
                                 <argument>-S</argument>
                             </arguments>
                         </configuration>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-vaadinVersion=23.2.0
+flowVersion=23.3-SNAPSHOT
 projectVersion=1.0-SNAPSHOT
 projectName=opentelemetry-vaadin-observability-instrumentation-extension
 # workaround for https://github.com/diffplug/spotless/issues/834


### PR DESCRIPTION
Use Flow version instead of platform to avoid circular dependencies.