### PR TITLE
Apply muzzle transformation to the instrumentation module

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <extension.name>opentelemetry-vaadin-observability-instrumentation-extension</extension.name>
         <google.auto-service.version>1.0</google.auto-service.version>
+        <byte-buddy.plugin.version>1.13.0</byte-buddy.plugin.version>
     </properties>
 
     <dependencies>
@@ -76,6 +77,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
         <!--
         This dependency is required to be used as the main artifact for the
         resulting agent JAR so we need it here even if it's not used, but it is
@@ -114,6 +120,37 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-maven-plugin</artifactId>
+                <version>${byte-buddy.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.opentelemetry.javaagent</groupId>
+                        <artifactId>opentelemetry-muzzle</artifactId>
+                        <version>${opentelemetry.version}-alpha</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.google.auto.service</groupId>
+                        <artifactId>auto-service</artifactId>
+                        <version>${google.auto-service.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>transform</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <transformations>
+                        <transformation>
+                            <plugin>com.vaadin.extension.ClasspathByteBuddyPlugin</plugin>
+                        </transformation>
+                    </transformations>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/ClasspathByteBuddyPlugin.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/ClasspathByteBuddyPlugin.java
@@ -1,0 +1,52 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.extension;
+
+import java.io.IOException;
+import java.net.URLClassLoader;
+
+import io.opentelemetry.javaagent.tooling.muzzle.generation.MuzzleCodeGenerationPlugin;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+
+/**
+ * Wrapper for OpenTelemetry {@link MuzzleCodeGenerationPlugin} to provide the
+ * current {@link URLClassLoader} and instrument the instrumentation module.
+ */
+public class ClasspathByteBuddyPlugin implements Plugin {
+
+    private final Plugin delegate;
+
+    /**
+     * Creates the plugin instance.
+     */
+    public ClasspathByteBuddyPlugin() {
+        URLClassLoader cl = (URLClassLoader) getClass().getClassLoader();
+        delegate = new MuzzleCodeGenerationPlugin(cl);
+    }
+
+    @Override
+    public boolean matches(TypeDescription target) {
+        return delegate.matches(target);
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public Builder<?> apply(Builder<?> builder, TypeDescription typeDescription,
+            ClassFileLocator classFileLocator) {
+        return delegate.apply(builder, typeDescription, classFileLocator);
+    }
+}

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
@@ -54,10 +54,8 @@ import java.util.Map;
 import java.util.Optional;
 
 public class InstrumentationHelper {
-
-    final static String INSTRUMENTATION_NAME = "opentelemetry-vaadin-observability-instrumentation-extension";
-    final static String PRODUCT_NAME = "vaadin-observability-kit";
-    final static String VERSION = "2.0";
+    public static final String INSTRUMENTATION_NAME = "com.vaadin.observability.instrumentation";
+    public static final String INSTRUMENTATION_VERSION = "2.0";
 
     private static final SpanNameGenerator generator = new SpanNameGenerator();
     private static final SpanAttributeGenerator attrGet = new SpanAttributeGenerator();
@@ -65,13 +63,13 @@ public class InstrumentationHelper {
     public static final Instrumenter<InstrumentationRequest, Void> INSTRUMENTER = Instrumenter
             .<InstrumentationRequest, Void> builder(GlobalOpenTelemetry.get(),
                     INSTRUMENTATION_NAME, generator)
-            .setInstrumentationVersion(VERSION)
+            .setInstrumentationVersion(INSTRUMENTATION_VERSION)
             .addAttributesExtractor(attrGet)
             .buildInstrumenter(InstrumentationRequest::getSpanKind);
 
     public static Tracer getTracer() {
         return GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME,
-                VERSION);
+                INSTRUMENTATION_VERSION);
     }
 
     /**

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -53,13 +53,16 @@ public class VaadinObservabilityInstrumentationModule
 
     static {
         LicenseChecker.checkLicenseFromStaticBlock(
-                InstrumentationHelper.PRODUCT_NAME,
-                InstrumentationHelper.VERSION, BuildType.PRODUCTION);
+                "vaadin-observability-kit",
+                InstrumentationHelper.INSTRUMENTATION_VERSION, BuildType.PRODUCTION);
     }
 
+    public static final String INSTRUMENTATION_NAME = "vaadin-observability-kit";
+    public static final String EXTENDED_NAME = "opentelemetry-vaadin-observability-instrumentation-extension-"
+            + InstrumentationHelper.INSTRUMENTATION_VERSION;
+
     public VaadinObservabilityInstrumentationModule() {
-        super(InstrumentationHelper.PRODUCT_NAME,
-                InstrumentationHelper.INSTRUMENTATION_NAME);
+        super(INSTRUMENTATION_NAME, EXTENDED_NAME);
     }
 
     @Override

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -52,9 +52,9 @@ public class VaadinObservabilityInstrumentationModule
         extends InstrumentationModule {
 
     static {
-        LicenseChecker.checkLicenseFromStaticBlock(
-                "vaadin-observability-kit",
-                InstrumentationHelper.INSTRUMENTATION_VERSION, BuildType.PRODUCTION);
+        LicenseChecker.checkLicenseFromStaticBlock("vaadin-observability-kit",
+                InstrumentationHelper.INSTRUMENTATION_VERSION,
+                BuildType.PRODUCTION);
     }
 
     public static final String INSTRUMENTATION_NAME = "vaadin-observability-kit";

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
@@ -9,6 +9,7 @@
  */
 package com.vaadin.extension.metrics;
 
+import com.vaadin.extension.InstrumentationHelper;
 import com.vaadin.flow.server.VaadinSession;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -40,8 +41,10 @@ public class Metrics {
         // Ensure meters are only created once
         if (registered.compareAndSet(false, true)) {
             Meter meter = GlobalOpenTelemetry
-                    .meterBuilder("com.vaadin.observability.instrumentation")
-                    .setInstrumentationVersion("1.0-alpha").build();
+                    .meterBuilder(InstrumentationHelper.INSTRUMENTATION_NAME)
+                    .setInstrumentationVersion(
+                            InstrumentationHelper.INSTRUMENTATION_VERSION)
+                    .build();
 
             meter.gaugeBuilder("vaadin.session.count").ofLongs()
                     .setDescription("Number of open sessions").setUnit("count")

--- a/observability-kit-agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
+++ b/observability-kit-agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
@@ -1,0 +1,1 @@
+com.vaadin.extension.ClasspathByteBuddyPlugin

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
@@ -32,7 +32,7 @@ class InstrumentationHelperTest extends AbstractInstrumentationTest {
 
     @Test
     public void assertInstrumentationVersionSet() {
-        assertThat(getVersion(), startsWith(InstrumentationHelper.VERSION));
+        assertThat(getVersion(), startsWith(InstrumentationHelper.INSTRUMENTATION_VERSION));
     }
 
     private String getVersion() {

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
@@ -32,7 +32,8 @@ class InstrumentationHelperTest extends AbstractInstrumentationTest {
 
     @Test
     public void assertInstrumentationVersionSet() {
-        assertThat(getVersion(), startsWith(InstrumentationHelper.INSTRUMENTATION_VERSION));
+        assertThat(getVersion(),
+                startsWith(InstrumentationHelper.INSTRUMENTATION_VERSION));
     }
 
     private String getVersion() {

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <flow.version>24.0-SNAPSHOT</flow.version>
         <servlet.api.version>6.0.0</servlet.api.version>
-        <opentelemetry.version>1.22.0</opentelemetry.version>
+        <opentelemetry.version>1.23.0</opentelemetry.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.shade.version>3.4.1</maven.shade.version>
         <maven.source.version>3.2.1</maven.source.version>


### PR DESCRIPTION
Restore original instrumentation name used in the Gradle build to verify if it fixes the issues with the agent.

Note the the string `"com.vaadin.observability.instrumentation"` is also used here:

https://github.com/vaadin/observability-kit/blob/70012eade3e02c1781ebff9fa76033175c1825cd/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java#L42-L44

Not sure if that is relevant, but also the version should probably be updated there.