### PR TITLE
feat: Client-side instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 **/target
 **/error-screenshots
+**/node_modules
 
 **/.sts4-cache/*
 .factorypath

--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <extension.name>opentelemetry-vaadin-observability-instrumentation-extension</extension.name>
         <google.auto-service.version>1.0</google.auto-service.version>
+        <byte-buddy.plugin.version>1.13.0</byte-buddy.plugin.version>
     </properties>
 
     <dependencies>
@@ -76,6 +77,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
         <!--
         This dependency is required to be used as the main artifact for the
         resulting agent JAR so we need it here even if it's not used, but it is
@@ -114,6 +120,37 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-maven-plugin</artifactId>
+                <version>${byte-buddy.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.opentelemetry.javaagent</groupId>
+                        <artifactId>opentelemetry-muzzle</artifactId>
+                        <version>${opentelemetry.version}-alpha</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.google.auto.service</groupId>
+                        <artifactId>auto-service</artifactId>
+                        <version>${google.auto-service.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>transform</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <transformations>
+                        <transformation>
+                            <plugin>com.vaadin.extension.ClasspathByteBuddyPlugin</plugin>
+                        </transformation>
+                    </transformations>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/ClasspathByteBuddyPlugin.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/ClasspathByteBuddyPlugin.java
@@ -1,0 +1,52 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.extension;
+
+import java.io.IOException;
+import java.net.URLClassLoader;
+
+import io.opentelemetry.javaagent.tooling.muzzle.generation.MuzzleCodeGenerationPlugin;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+
+/**
+ * Wrapper for OpenTelemetry {@link MuzzleCodeGenerationPlugin} to provide the
+ * current {@link URLClassLoader} and instrument the instrumentation module.
+ */
+public class ClasspathByteBuddyPlugin implements Plugin {
+
+    private final Plugin delegate;
+
+    /**
+     * Creates the plugin instance.
+     */
+    public ClasspathByteBuddyPlugin() {
+        URLClassLoader cl = (URLClassLoader) getClass().getClassLoader();
+        delegate = new MuzzleCodeGenerationPlugin(cl);
+    }
+
+    @Override
+    public boolean matches(TypeDescription target) {
+        return delegate.matches(target);
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public Builder<?> apply(Builder<?> builder, TypeDescription typeDescription,
+            ClassFileLocator classFileLocator) {
+        return delegate.apply(builder, typeDescription, classFileLocator);
+    }
+}

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
@@ -54,10 +54,8 @@ import java.util.Map;
 import java.util.Optional;
 
 public class InstrumentationHelper {
-
-    final static String INSTRUMENTATION_NAME = "opentelemetry-vaadin-observability-instrumentation-extension";
-    final static String PRODUCT_NAME = "vaadin-observability-kit";
-    final static String VERSION = "2.0";
+    public static final String INSTRUMENTATION_NAME = "com.vaadin.observability.instrumentation";
+    public static final String INSTRUMENTATION_VERSION = "2.0";
 
     private static final SpanNameGenerator generator = new SpanNameGenerator();
     private static final SpanAttributeGenerator attrGet = new SpanAttributeGenerator();
@@ -65,13 +63,13 @@ public class InstrumentationHelper {
     public static final Instrumenter<InstrumentationRequest, Void> INSTRUMENTER = Instrumenter
             .<InstrumentationRequest, Void> builder(GlobalOpenTelemetry.get(),
                     INSTRUMENTATION_NAME, generator)
-            .setInstrumentationVersion(VERSION)
+            .setInstrumentationVersion(INSTRUMENTATION_VERSION)
             .addAttributesExtractor(attrGet)
             .buildInstrumenter(InstrumentationRequest::getSpanKind);
 
     public static Tracer getTracer() {
         return GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME,
-                VERSION);
+                INSTRUMENTATION_VERSION);
     }
 
     /**

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -12,6 +12,7 @@ package com.vaadin.extension;
 import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
 
 import com.vaadin.extension.instrumentation.AbstractNavigationStateRendererInstrumentation;
+import com.vaadin.extension.instrumentation.client.ClientInstrumentation;
 import com.vaadin.extension.instrumentation.communication.HeartbeatHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.communication.JavaScriptBootstrapHandlerInstrumentation;
 import com.vaadin.extension.instrumentation.communication.PwaHandlerInstrumentation;
@@ -85,7 +86,7 @@ public class VaadinObservabilityInstrumentationModule
         return Stream
                 .of(instrumentation(), rpcHandlerInstrumentation(),
                         requestHandlerInstrumentation(), dataInstrumentation(),
-                        serverInstrumentation())
+                        serverInstrumentation(), clientInstrumentation())
                 .flatMap(i -> i).collect(Collectors.toList());
     }
 
@@ -135,6 +136,12 @@ public class VaadinObservabilityInstrumentationModule
                 new StaticFileServerInstrumentation(),
                 new VaadinServletInstrumentation(),
                 new VaadinSessionInstrumentation());
+        // @formatter:on
+    }
+
+    private Stream<TypeInstrumentation> clientInstrumentation() {
+        // @formatter:off
+        return Stream.of(new ClientInstrumentation());
         // @formatter:on
     }
 }

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/VaadinObservabilityInstrumentationModule.java
@@ -52,14 +52,17 @@ public class VaadinObservabilityInstrumentationModule
         extends InstrumentationModule {
 
     static {
-        LicenseChecker.checkLicenseFromStaticBlock(
-                InstrumentationHelper.PRODUCT_NAME,
-                InstrumentationHelper.VERSION, BuildType.PRODUCTION);
+        LicenseChecker.checkLicenseFromStaticBlock("vaadin-observability-kit",
+                InstrumentationHelper.INSTRUMENTATION_VERSION,
+                BuildType.PRODUCTION);
     }
 
+    public static final String INSTRUMENTATION_NAME = "vaadin-observability-kit";
+    public static final String EXTENDED_NAME = "opentelemetry-vaadin-observability-instrumentation-extension-"
+            + InstrumentationHelper.INSTRUMENTATION_VERSION;
+
     public VaadinObservabilityInstrumentationModule() {
-        super(InstrumentationHelper.PRODUCT_NAME,
-                InstrumentationHelper.INSTRUMENTATION_NAME);
+        super(INSTRUMENTATION_NAME, EXTENDED_NAME);
     }
 
     @Override

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ClientInstrumentation.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ClientInstrumentation.java
@@ -1,0 +1,135 @@
+package com.vaadin.extension.instrumentation.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import com.vaadin.extension.InstrumentationHelper;
+
+import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.hasClassesNamed;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class ClientInstrumentation implements TypeInstrumentation {
+    @Override
+    public ElementMatcher<ClassLoader> classLoaderOptimization() {
+        return hasClassesNamed("com.vaadin.observability.ObservabilityHandler");
+    }
+
+    @Override
+    public ElementMatcher<TypeDescription> typeMatcher() {
+        return named("com.vaadin.observability.ObservabilityHandler");
+    }
+
+    @Override
+    public void transform(TypeTransformer transformer) {
+        transformer.applyAdviceToMethod(named("handleTraces"),
+                this.getClass().getName() + "$MethodAdvice");
+    }
+
+    public static class MethodAdvice {
+        @Advice.OnMethodEnter()
+        public static void onEnter(@Advice.Argument(0) JsonNode root) {
+            Tracer tracer = InstrumentationHelper.getTracer();
+
+            for (JsonNode resourceSpanNode : root.get("resourceSpans")) {
+                for (JsonNode scopeSpanNode : resourceSpanNode
+                        .get("scopeSpans")) {
+
+                    Map<String, JsonNode> parentSpanNodes = new HashMap<>();
+                    Map<String, JsonNode> childSpanNodes = new HashMap<>();
+                    for (JsonNode spanNode : scopeSpanNode.get("spans")) {
+                        if (spanNode.has("parentSpanId")) {
+                            childSpanNodes.put(spanNode.get("spanId").asText(),
+                                    spanNode);
+                        } else {
+                            parentSpanNodes.put(spanNode.get("spanId").asText(),
+                                    spanNode);
+                        }
+                    }
+
+                    for (Map.Entry<String, JsonNode> parentEntry : parentSpanNodes
+                            .entrySet()) {
+                        String parentSpanId = parentEntry.getKey();
+                        JsonNode parentSpanNode = parentEntry.getValue();
+
+                        Span parentSpan = createSpan(tracer, parentSpanNode);
+
+                        for (Map.Entry<String, JsonNode> childEntry : childSpanNodes
+                                .entrySet()) {
+                            JsonNode childSpanNode = childEntry.getValue();
+
+                            if (parentSpanId.equals(childSpanNode
+                                    .get("parentSpanId").asText())) {
+                                Span childSpan = createSpan(tracer,
+                                        childSpanNode);
+                                childSpan.end(
+                                        childSpanNode.get("endTimeUnixNano")
+                                                .asLong(),
+                                        TimeUnit.NANOSECONDS);
+                            }
+                        }
+
+                        parentSpan.end(
+                                parentSpanNode.get("endTimeUnixNano").asLong(),
+                                TimeUnit.NANOSECONDS);
+                    }
+
+                    if (parentSpanNodes.size() == 0) {
+                        for (Map.Entry<String, JsonNode> childEntry : childSpanNodes
+                                .entrySet()) {
+                            JsonNode childSpanNode = childEntry.getValue();
+
+                            Span childSpan = createSpan(tracer, childSpanNode);
+                            childSpan.end(childSpanNode.get("endTimeUnixNano")
+                                    .asLong(), TimeUnit.NANOSECONDS);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static Span createSpan(Tracer tracer, JsonNode spanNode) {
+            SpanBuilder spanBuilder = tracer
+                    .spanBuilder("Client: " + spanNode.get("name").asText());
+            spanBuilder.setSpanKind(SpanKind.SERVER);
+            spanBuilder.setStartTimestamp(
+                    spanNode.get("startTimeUnixNano").asLong(),
+                    TimeUnit.NANOSECONDS);
+
+            Span span = spanBuilder.startSpan();
+            int status = spanNode.get("status").get("code").asInt();
+            span.setStatus(StatusCode.values()[status + 1]);
+
+            for (JsonNode attributeNode : spanNode.get("attributes")) {
+                if (attributeNode.get("value").has("stringValue")) {
+                    span.setAttribute(attributeNode.get("key").asText(),
+                            attributeNode.get("value").get("stringValue")
+                                    .asText());
+                } else if (attributeNode.get("value").has("intValue")) {
+                    span.setAttribute(attributeNode.get("key").asText(),
+                            attributeNode.get("value").get("intValue").asInt());
+                }
+            }
+
+            for (JsonNode eventNode : spanNode.get("events")) {
+                span.addEvent(eventNode.get("name").asText(),
+                        eventNode.get("timeUnixNano").asLong(),
+                        TimeUnit.NANOSECONDS);
+            }
+
+            return span;
+        }
+    }
+}

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
@@ -9,6 +9,7 @@
  */
 package com.vaadin.extension.metrics;
 
+import com.vaadin.extension.InstrumentationHelper;
 import com.vaadin.flow.server.VaadinSession;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
@@ -40,8 +41,10 @@ public class Metrics {
         // Ensure meters are only created once
         if (registered.compareAndSet(false, true)) {
             Meter meter = GlobalOpenTelemetry
-                    .meterBuilder("com.vaadin.observability.instrumentation")
-                    .setInstrumentationVersion("1.0-alpha").build();
+                    .meterBuilder(InstrumentationHelper.INSTRUMENTATION_NAME)
+                    .setInstrumentationVersion(
+                            InstrumentationHelper.INSTRUMENTATION_VERSION)
+                    .build();
 
             meter.gaugeBuilder("vaadin.session.count").ofLongs()
                     .setDescription("Number of open sessions").setUnit("count")

--- a/observability-kit-agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
+++ b/observability-kit-agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
@@ -1,0 +1,1 @@
+com.vaadin.extension.ClasspathByteBuddyPlugin

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/InstrumentationHelperTest.java
@@ -32,7 +32,8 @@ class InstrumentationHelperTest extends AbstractInstrumentationTest {
 
     @Test
     public void assertInstrumentationVersionSet() {
-        assertThat(getVersion(), startsWith(InstrumentationHelper.VERSION));
+        assertThat(getVersion(),
+                startsWith(InstrumentationHelper.INSTRUMENTATION_VERSION));
     }
 
     private String getVersion() {

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/client/ClientInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/client/ClientInstrumentationTest.java
@@ -1,0 +1,68 @@
+package com.vaadin.extension.instrumentation.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ClientInstrumentationTest extends AbstractInstrumentationTest {
+    @Test
+    public void handleRequest_createsSpan() {
+        try {
+            // @formatter:off
+            String jsonString = "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"unknown_service\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"webjs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.9.0\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"@opentelemetry/instrumentation-document-load\",\"version\":\"0.31.0\"},\"spans\":[{\"traceId\":\"b7e726b6155ac52912322123d2f31a2c\",\"spanId\":\"67279b5c43e6874c\",\"name\":\"documentLoad\",\"kind\":1,\"startTimeUnixNano\":1674542404352000000,\"endTimeUnixNano\":1674542405301000200,\"attributes\":[{\"key\":\"component\",\"value\":{\"stringValue\":\"document-load\"}},{\"key\":\"http.url\",\"value\":{\"stringValue\":\"http://localhost:8080/login\"}},{\"key\":\"http.user_agent\",\"value\":{\"stringValue\":\"Mozilla/5.0(WindowsNT10.0;Win64;x64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/109.0.0.0Safari/537.36\"}}],\"droppedAttributesCount\":0,\"events\":[{\"attributes\":[],\"name\":\"fetchStart\",\"timeUnixNano\":1674542404352000000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"unloadEventStart\",\"timeUnixNano\":1674542404385100000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"unloadEventEnd\",\"timeUnixNano\":1674542404385700000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domInteractive\",\"timeUnixNano\":1674542404468400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domContentLoadedEventStart\",\"timeUnixNano\":1674542405284400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domContentLoadedEventEnd\",\"timeUnixNano\":1674542405287600000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domComplete\",\"timeUnixNano\":1674542405293900000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"loadEventStart\",\"timeUnixNano\":1674542405300900000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"loadEventEnd\",\"timeUnixNano\":1674542405301000200,\"droppedAttributesCount\":0}],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}";
+            // @formatter:on
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(jsonString);
+
+            ClientInstrumentation.MethodAdvice.onEnter(root);
+
+            SpanData span = getExportedSpan(0);
+            assertEquals("Client: documentLoad", span.getName());
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void handleRequest_createsParentAndChildSpans() {
+        try {
+            // @formatter:off
+            String jsonString = "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"unknown_service\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"webjs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.9.0\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"@opentelemetry/instrumentation-document-load\",\"version\":\"0.31.0\"},\"spans\":[{\"traceId\":\"b7e726b6155ac52912322123d2f31a2c\",\"spanId\":\"52226f938f423db4\",\"parentSpanId\":\"67279b5c43e6874c\",\"name\":\"documentFetch\",\"kind\":1,\"startTimeUnixNano\":1674542404351400000,\"endTimeUnixNano\":1674542404377600000,\"attributes\":[{\"key\":\"component\",\"value\":{\"stringValue\":\"document-load\"}},{\"key\":\"http.url\",\"value\":{\"stringValue\":\"http://localhost:8080/login\"}},{\"key\":\"http.response_content_length\",\"value\":{\"intValue\":0}}],\"droppedAttributesCount\":0,\"events\":[{\"attributes\":[],\"name\":\"fetchStart\",\"timeUnixNano\":1674542404351400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domainLookupStart\",\"timeUnixNano\":1674542404351400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domainLookupEnd\",\"timeUnixNano\":1674542404351400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"connectStart\",\"timeUnixNano\":1674542404351400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"secureConnectionStart\",\"timeUnixNano\":1674542404339500000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"connectEnd\",\"timeUnixNano\":1674542404351400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"requestStart\",\"timeUnixNano\":1674542404351400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"responseStart\",\"timeUnixNano\":1674542404377400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"responseEnd\",\"timeUnixNano\":1674542404377600000,\"droppedAttributesCount\":0}],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b7e726b6155ac52912322123d2f31a2c\",\"spanId\":\"67279b5c43e6874c\",\"name\":\"documentLoad\",\"kind\":1,\"startTimeUnixNano\":1674542404352000000,\"endTimeUnixNano\":1674542405301000200,\"attributes\":[{\"key\":\"component\",\"value\":{\"stringValue\":\"document-load\"}},{\"key\":\"http.url\",\"value\":{\"stringValue\":\"http://localhost:8080/login\"}},{\"key\":\"http.user_agent\",\"value\":{\"stringValue\":\"Mozilla/5.0(WindowsNT10.0;Win64;x64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/109.0.0.0Safari/537.36\"}}],\"droppedAttributesCount\":0,\"events\":[{\"attributes\":[],\"name\":\"fetchStart\",\"timeUnixNano\":1674542404352000000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"unloadEventStart\",\"timeUnixNano\":1674542404385100000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"unloadEventEnd\",\"timeUnixNano\":1674542404385700000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domInteractive\",\"timeUnixNano\":1674542404468400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domContentLoadedEventStart\",\"timeUnixNano\":1674542405284400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domContentLoadedEventEnd\",\"timeUnixNano\":1674542405287600000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domComplete\",\"timeUnixNano\":1674542405293900000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"loadEventStart\",\"timeUnixNano\":1674542405300900000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"loadEventEnd\",\"timeUnixNano\":1674542405301000200,\"droppedAttributesCount\":0}],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}";
+            // @formatter:on
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(jsonString);
+
+            ClientInstrumentation.MethodAdvice.onEnter(root);
+
+            SpanData parentSpan = getExportedSpan(1);
+            SpanData childSpan = getExportedSpan(0);
+            assertEquals(parentSpan.getSpanId(), childSpan.getParentSpanId());
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void handleRequest_notHandled() {
+        try {
+            String jsonString = "{}";
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(jsonString);
+
+            ClientInstrumentation.MethodAdvice.onEnter(root);
+
+            assertEquals(0, getExportedSpanCount());
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+}

--- a/observability-kit-starter/package.json
+++ b/observability-kit-starter/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "observability-kit-starter",
+  "version": "2.0.0",
+  "dependencies": {
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/context-zone": "1.8.0",
+    "@opentelemetry/core": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.35.0",
+    "@opentelemetry/instrumentation": "0.35.0",
+    "@opentelemetry/instrumentation-document-load": "0.31.0",
+    "@opentelemetry/instrumentation-long-task": "^0.32.0",
+    "@opentelemetry/instrumentation-user-interaction": "0.32.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.34.0",
+    "@opentelemetry/otlp-transformer": "^0.35.0",
+    "@opentelemetry/resources": "1.9.0",
+    "@opentelemetry/sdk-trace-base": "1.9.0",
+    "@opentelemetry/sdk-trace-web": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0",
+    "lit": "^2.2.7"
+  },
+  "vaadin": {
+    "dependencies": {
+      "@opentelemetry/resources": "1.9.0",
+      "@opentelemetry/semantic-conventions": "1.8.0",
+      "@opentelemetry/sdk-trace-base": "1.9.0",
+      "@opentelemetry/sdk-trace-web": "1.8.0",
+      "@opentelemetry/exporter-trace-otlp-http": "0.35.0",
+      "@opentelemetry/instrumentation-document-load": "0.31.0",
+      "@opentelemetry/instrumentation-user-interaction": "0.32.0",
+      "@opentelemetry/instrumentation-xml-http-request": "0.34.0",
+      "@opentelemetry/context-zone": "1.8.0",
+      "@opentelemetry/instrumentation": "0.35.0",
+      "lit": "^2.2.7"
+    }
+  }
+}

--- a/observability-kit-starter/pom.xml
+++ b/observability-kit-starter/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>observability-kit</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>observability-kit-starter</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${servlet.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.7.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <quiet>true</quiet>
+                    <doclint>none</doclint>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>${maven.formatter.version}</version>
+                <configuration>
+                    <configFile>https://raw.githubusercontent.com/vaadin/flow/master/eclipse/VaadinJavaConventions.xml</configFile>
+                    <skipHtmlFormatting>true</skipHtmlFormatting>
+                    <lineEnding>LF</lineEnding>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
@@ -1,0 +1,10 @@
+package com.vaadin.observability;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+
+@Tag("vaadin-observability-client")
+@JsModule("./components/observability-client.ts")
+public class ObservabilityClient extends Component {
+}

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
@@ -3,7 +3,21 @@ package com.vaadin.observability;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
 
+@NpmPackage(value = "lit", version = "")
+@NpmPackage(value = "@opentelemetry/sdk-trace-web", version = "1.8.0")
+@NpmPackage(value = "@opentelemetry/instrumentation", version = "0.35.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-document-load",
+        version = "0.31.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-user-interaction",
+        version = "0.32.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-xml-http-request",
+        version = "0.34.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-long-task",
+        version = "0.32.0")
+@NpmPackage(value = "@opentelemetry/exporter-trace-otlp-http",
+        version = "0.35.0")
 @Tag("vaadin-observability-client")
 @JsModule("./components/observability-client.ts")
 public class ObservabilityClient extends Component {

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
@@ -8,16 +8,11 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "lit", version = "")
 @NpmPackage(value = "@opentelemetry/sdk-trace-web", version = "1.8.0")
 @NpmPackage(value = "@opentelemetry/instrumentation", version = "0.35.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-document-load",
-        version = "0.31.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-user-interaction",
-        version = "0.32.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-xml-http-request",
-        version = "0.34.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-long-task",
-        version = "0.32.0")
-@NpmPackage(value = "@opentelemetry/exporter-trace-otlp-http",
-        version = "0.35.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-document-load", version = "0.31.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-user-interaction", version = "0.32.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-xml-http-request", version = "0.34.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-long-task", version = "0.32.0")
+@NpmPackage(value = "@opentelemetry/exporter-trace-otlp-http", version = "0.35.0")
 @Tag("vaadin-observability-client")
 @JsModule("./components/observability-client.ts")
 public class ObservabilityClient extends Component {

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
@@ -15,5 +15,5 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@opentelemetry/exporter-trace-otlp-http", version = "0.35.0")
 @Tag("vaadin-observability-client")
 @JsModule("./components/observability-client.ts")
-public class ObservabilityClient extends Component {
+class ObservabilityClient extends Component {
 }

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
@@ -46,15 +46,21 @@ public class ObservabilityHandler extends SynchronizedRequestHandler {
                 newObservabilityHandler);
 
         ui.addAttachListener(attachEvent -> {
-            if (ComponentUtil.getData(ui, ObservabilityHandler.class) == null) {
-                session.addRequestHandler(newObservabilityHandler);
-                ComponentUtil.setData(ui, ObservabilityHandler.class,
+            UI attachUI = attachEvent.getUI();
+            VaadinSession attachSession = attachEvent.getSession();
+            if (ComponentUtil.getData(attachUI, ObservabilityHandler.class) == null) {
+                attachSession.addRequestHandler(newObservabilityHandler);
+                ComponentUtil.setData(attachUI, ObservabilityHandler.class,
                         newObservabilityHandler);
             }
         });
         ui.addDetachListener(detachEvent -> {
-            session.removeRequestHandler(newObservabilityHandler);
-            ComponentUtil.setData(ui, ObservabilityHandler.class, null);
+            UI detachUI = detachEvent.getUI();
+            VaadinSession detachSession = detachEvent.getSession();
+            if (ComponentUtil.getData(detachUI, ObservabilityHandler.class) != null) {
+                detachSession.removeRequestHandler(newObservabilityHandler);
+                ComponentUtil.setData(detachUI, ObservabilityHandler.class, null);
+            }
         });
         return newObservabilityHandler;
     }

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
@@ -38,16 +38,15 @@ public class ObservabilityHandler extends SynchronizedRequestHandler {
             return observabilityHandler;
         }
 
-        ObservabilityHandler newObservabilityHandler =
-                new ObservabilityHandler();
+        ObservabilityHandler newObservabilityHandler = new ObservabilityHandler();
 
         VaadinSession session = ui.getSession();
         session.addRequestHandler(newObservabilityHandler);
         ComponentUtil.setData(ui, ObservabilityHandler.class,
                 newObservabilityHandler);
 
-        ui.addDetachListener(detachEvent ->
-                session.removeRequestHandler(newObservabilityHandler));
+        ui.addDetachListener(detachEvent -> session
+                .removeRequestHandler(newObservabilityHandler));
         return newObservabilityHandler;
     }
 

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
@@ -45,8 +45,17 @@ public class ObservabilityHandler extends SynchronizedRequestHandler {
         ComponentUtil.setData(ui, ObservabilityHandler.class,
                 newObservabilityHandler);
 
-        ui.addDetachListener(detachEvent -> session
-                .removeRequestHandler(newObservabilityHandler));
+        ui.addAttachListener(attachEvent -> {
+            if (ComponentUtil.getData(ui, ObservabilityHandler.class) == null) {
+                session.addRequestHandler(newObservabilityHandler);
+                ComponentUtil.setData(ui, ObservabilityHandler.class,
+                        newObservabilityHandler);
+            }
+        });
+        ui.addDetachListener(detachEvent -> {
+            session.removeRequestHandler(newObservabilityHandler);
+            ComponentUtil.setData(ui, ObservabilityHandler.class, null);
+        });
         return newObservabilityHandler;
     }
 

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityHandler.java
@@ -1,0 +1,105 @@
+package com.vaadin.observability;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.SynchronizedRequestHandler;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.shared.ApplicationConstants;
+
+public class ObservabilityHandler extends SynchronizedRequestHandler {
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ObservabilityHandler.class);
+    }
+
+    private static final String PATH = "/";
+    private static final String ID_PARAMETER = "id";
+    private static final String REQUEST_TYPE = "o11y";
+    private static final String HTTP_METHOD = "POST";
+    private static final String CONTENT_TYPE = "application/json";
+
+    private final String id = UUID.randomUUID().toString();
+
+    static ObservabilityHandler ensureInstalled(UI ui) {
+        ObservabilityHandler observabilityHandler = ComponentUtil.getData(ui,
+                ObservabilityHandler.class);
+        if (observabilityHandler != null) {
+            // Already installed, return the existing handler
+            return observabilityHandler;
+        }
+
+        ObservabilityHandler newObservabilityHandler =
+                new ObservabilityHandler();
+
+        VaadinSession session = ui.getSession();
+        session.addRequestHandler(newObservabilityHandler);
+        ComponentUtil.setData(ui, ObservabilityHandler.class,
+                newObservabilityHandler);
+
+        ui.addDetachListener(detachEvent ->
+                session.removeRequestHandler(newObservabilityHandler));
+        return newObservabilityHandler;
+    }
+
+    @Override
+    protected boolean canHandleRequest(VaadinRequest request) {
+        if (!PATH.equals(request.getPathInfo())) {
+            return false;
+        }
+        String requestType = request
+                .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER);
+        String instanceId = request.getParameter(ID_PARAMETER);
+        return REQUEST_TYPE.equals(requestType) && id.equals(instanceId);
+    }
+
+    @Override
+    public boolean synchronizedHandleRequest(VaadinSession session,
+            VaadinRequest request, VaadinResponse response) {
+        if (!HTTP_METHOD.equals(request.getMethod())) {
+            response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return true;
+        }
+        if (!CONTENT_TYPE.equals(request.getContentType())) {
+            response.setStatus(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE);
+            return true;
+        }
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(request.getInputStream());
+
+            if (!root.has("resourceSpans")) {
+                getLogger().error("Malformed traces message.");
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                return true;
+            }
+
+            handleTraces(root);
+
+            response.setStatus(HttpServletResponse.SC_OK);
+        } catch (IOException e) {
+            getLogger().error("Exception when processing traces.");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+
+        return true;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    private void handleTraces(JsonNode root) {
+        // Dummy method for the agent to hook onto
+    }
+}

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
@@ -7,23 +7,9 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
-@NpmPackage(value = "lit", version = "")
-@NpmPackage(value = "@opentelemetry/sdk-trace-web", version = "1.8.0")
-@NpmPackage(value = "@opentelemetry/instrumentation", version = "0.35.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-document-load",
-        version = "0.31.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-user-interaction",
-        version = "0.32.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-xml-http-request",
-        version = "0.34.0")
-@NpmPackage(value = "@opentelemetry/instrumentation-long-task",
-        version = "0.32.0")
-@NpmPackage(value = "@opentelemetry/exporter-trace-otlp-http",
-        version = "0.35.0")
 public class ObservabilityServiceInitListener
         implements VaadinServiceInitListener {
     private static Logger getLogger() {

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
@@ -22,8 +22,8 @@ public class ObservabilityServiceInitListener
         serviceInitEvent.getSource().addUIInitListener(event -> {
             UI ui = event.getUI();
 
-            ObservabilityHandler handler =
-                    ObservabilityHandler.ensureInstalled(ui);
+            ObservabilityHandler handler = ObservabilityHandler
+                    .ensureInstalled(ui);
 
             Optional<Component> existingClient = ui.getChildren()
                     .filter(child -> (child instanceof ObservabilityClient))

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
@@ -1,0 +1,54 @@
+package com.vaadin.observability;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+@NpmPackage(value = "lit", version = "")
+@NpmPackage(value = "@opentelemetry/sdk-trace-web", version = "1.8.0")
+@NpmPackage(value = "@opentelemetry/instrumentation", version = "0.35.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-document-load",
+        version = "0.31.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-user-interaction",
+        version = "0.32.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-xml-http-request",
+        version = "0.34.0")
+@NpmPackage(value = "@opentelemetry/instrumentation-long-task",
+        version = "0.32.0")
+@NpmPackage(value = "@opentelemetry/exporter-trace-otlp-http",
+        version = "0.35.0")
+public class ObservabilityServiceInitListener
+        implements VaadinServiceInitListener {
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ObservabilityServiceInitListener.class);
+    }
+
+    public void serviceInit(ServiceInitEvent serviceInitEvent) {
+        getLogger().info("Initializing Observability Kit");
+
+        serviceInitEvent.getSource().addUIInitListener(event -> {
+            UI ui = event.getUI();
+
+            ObservabilityHandler handler =
+                    ObservabilityHandler.ensureInstalled(ui);
+
+            Optional<Component> existingClient = ui.getChildren()
+                    .filter(child -> (child instanceof ObservabilityClient))
+                    .findFirst();
+            if (existingClient.isPresent()) {
+                ui.remove(existingClient.get());
+            } else {
+                ObservabilityClient client = new ObservabilityClient();
+                client.getElement().setProperty("instanceId", handler.getId());
+                ui.add(client);
+            }
+        });
+    }
+}

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityServiceInitListener.java
@@ -1,11 +1,8 @@
 package com.vaadin.observability;
 
-import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
@@ -25,16 +22,13 @@ public class ObservabilityServiceInitListener
             ObservabilityHandler handler = ObservabilityHandler
                     .ensureInstalled(ui);
 
-            Optional<Component> existingClient = ui.getChildren()
+            ui.getChildren()
                     .filter(child -> (child instanceof ObservabilityClient))
-                    .findFirst();
-            if (existingClient.isPresent()) {
-                ui.remove(existingClient.get());
-            } else {
-                ObservabilityClient client = new ObservabilityClient();
-                client.getElement().setProperty("instanceId", handler.getId());
-                ui.add(client);
-            }
+                    .forEach(ui::remove);
+
+            ObservabilityClient client = new ObservabilityClient();
+            client.getElement().setProperty("instanceId", handler.getId());
+            ui.add(client);
         });
     }
 }

--- a/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
+++ b/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
@@ -1,0 +1,74 @@
+import {html, LitElement, nothing, PropertyValues} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {
+  BatchSpanProcessor,
+  StackContextManager,
+  WebTracerProvider
+} from "@opentelemetry/sdk-trace-web";
+import {registerInstrumentations} from "@opentelemetry/instrumentation";
+import {
+  DocumentLoadInstrumentation
+} from "@opentelemetry/instrumentation-document-load";
+import {
+  UserInteractionInstrumentation
+} from "@opentelemetry/instrumentation-user-interaction";
+import {
+  XMLHttpRequestInstrumentation
+} from "@opentelemetry/instrumentation-xml-http-request";
+import {
+  LongTaskInstrumentation
+} from "@opentelemetry/instrumentation-long-task";
+import {OTLPTraceExporter} from "@opentelemetry/exporter-trace-otlp-http";
+
+@customElement('vaadin-observability-client')
+export class ObservabilityClient extends LitElement {
+  provider: WebTracerProvider;
+  instanceId?: string;
+
+  constructor() {
+    super();
+
+    this.provider = new WebTracerProvider();
+  }
+
+  render() {
+    return html`${nothing}`;
+  }
+
+  protected firstUpdated(_changedProperties: PropertyValues) {
+    super.firstUpdated(_changedProperties);
+
+    const exporter = new OTLPTraceExporter({
+      url: '/?v-r=o11y&id=' + this.instanceId,
+    })
+    this.provider.addSpanProcessor(new BatchSpanProcessor(exporter, {
+      // The maximum queue size. After the size is reached spans are dropped.
+      maxQueueSize: 100,
+      // The maximum batch size of every export. It must be smaller or equal to maxQueueSize.
+      maxExportBatchSize: 10,
+      // The interval between two consecutive exports
+      scheduledDelayMillis: 500,
+      // How long the export can run before it is cancelled
+      exportTimeoutMillis: 30000,
+    }));
+
+    this.provider.register({
+      // Changing default contextManager to use StackContextManager
+      contextManager: new StackContextManager(),
+    });
+
+    //Registering instrumentations
+    registerInstrumentations({
+      instrumentations: [
+        new DocumentLoadInstrumentation(),
+        new UserInteractionInstrumentation(),
+        new XMLHttpRequestInstrumentation({
+          ignoreUrls: [
+            '/?v-r=o11y',
+          ]
+        }),
+        new LongTaskInstrumentation()
+      ],
+    });
+  }
+}

--- a/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
+++ b/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
@@ -24,6 +24,7 @@ import {OTLPTraceExporter} from "@opentelemetry/exporter-trace-otlp-http";
 export class ObservabilityClient extends LitElement {
   provider: WebTracerProvider;
   instanceId?: string;
+  unloadInstrumentations? : () => void;
 
   constructor() {
     super();
@@ -58,7 +59,7 @@ export class ObservabilityClient extends LitElement {
     });
 
     //Registering instrumentations
-    registerInstrumentations({
+    this.unloadInstrumentations = registerInstrumentations({
       instrumentations: [
         new DocumentLoadInstrumentation(),
         new UserInteractionInstrumentation(),
@@ -70,5 +71,13 @@ export class ObservabilityClient extends LitElement {
         new LongTaskInstrumentation()
       ],
     });
+  }
+
+  protected disconnectedCallback() {
+    super.disconnectedCallback();
+
+    if (this.unloadInstrumentations) {
+      this.unloadInstrumentations();
+    }
   }
 }

--- a/observability-kit-starter/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/observability-kit-starter/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+com.vaadin.observability.ObservabilityServiceInitListener

--- a/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityHandlerTest.java
+++ b/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityHandlerTest.java
@@ -1,0 +1,201 @@
+package com.vaadin.observability;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.shared.ApplicationConstants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class ObservabilityHandlerTest {
+    @Test
+    public void ensureInstalled_handlerIsInstalled() {
+        UI ui = mock(UI.class);
+        VaadinSession session = mock(VaadinSession.class);
+        when(ui.getSession()).thenReturn(session);
+
+        ObservabilityHandler.ensureInstalled(ui);
+
+        verify(session).addRequestHandler(any());
+    }
+
+    @Test
+    public void ensureInstalled_handlerExists_returnsExistingHandler() {
+        UI ui = mock(UI.class);
+        VaadinSession session = mock(VaadinSession.class);
+        when(ui.getSession()).thenReturn(session);
+
+        ObservabilityHandler handler = ObservabilityHandler.ensureInstalled(ui);
+
+        verify(session).addRequestHandler(any());
+
+        ObservabilityHandler handler1 = ObservabilityHandler
+                .ensureInstalled(ui);
+
+        verifyNoMoreInteractions(session);
+        assertEquals(handler, handler1);
+    }
+
+    @Test
+    public void canHandleRequest_invalidPath_returnsFalse() {
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getPathInfo()).thenReturn("");
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        assertFalse(handler.canHandleRequest(request));
+    }
+
+    @Test
+    public void canHandleRequest_invalidRequestType_returnsFalse() {
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getPathInfo()).thenReturn("/");
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn("beacon");
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        assertFalse(handler.canHandleRequest(request));
+    }
+
+    @Test
+    public void canHandleRequest_invalidId_returnsFalse() {
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getPathInfo()).thenReturn("/");
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn("o11y");
+        when(request.getParameter("id"))
+                .thenReturn(UUID.randomUUID().toString());
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        assertFalse(handler.canHandleRequest(request));
+    }
+
+    @Test
+    public void canHandleRequest_returnsTrue() {
+        ObservabilityHandler handler = new ObservabilityHandler();
+
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getPathInfo()).thenReturn("/");
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn("o11y");
+        when(request.getParameter("id")).thenReturn(handler.getId());
+
+        assertTrue(handler.canHandleRequest(request));
+    }
+
+    @Test
+    public void synchronizedHandleRequest_invalidMethod_methodNotAllowed() {
+        VaadinSession session = mock(VaadinSession.class);
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+        VaadinResponse response = mock(VaadinResponse.class);
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        boolean handled = handler.synchronizedHandleRequest(session, request,
+                response);
+
+        assertTrue(handled);
+        verify(response).setStatus(405);
+    }
+
+    @Test
+    public void synchronizedHandleRequest_invalidContentType_unsupportedType() {
+        VaadinSession session = mock(VaadinSession.class);
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getContentType()).thenReturn("text/html");
+        VaadinResponse response = mock(VaadinResponse.class);
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        boolean handled = handler.synchronizedHandleRequest(session, request,
+                response);
+
+        assertTrue(handled);
+        verify(response).setStatus(415);
+    }
+
+    @Test
+    public void synchronizedHandleRequest_invalidBody_badRequest() {
+        VaadinSession session = mock(VaadinSession.class);
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getContentType()).thenReturn("application/json");
+        try {
+            InputStream targetStream = new ByteArrayInputStream(
+                    "body".getBytes());
+            when(request.getInputStream()).thenReturn(targetStream);
+        } catch (IOException e) {
+            fail(e);
+        }
+        VaadinResponse response = mock(VaadinResponse.class);
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        boolean handled = handler.synchronizedHandleRequest(session, request,
+                response);
+
+        assertTrue(handled);
+        verify(response).setStatus(400);
+    }
+
+    @Test
+    public void synchronizedHandleRequest_invalidJson_badRequest() {
+        VaadinSession session = mock(VaadinSession.class);
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getContentType()).thenReturn("application/json");
+        try {
+            InputStream targetStream = new ByteArrayInputStream(
+                    "{}".getBytes());
+            when(request.getInputStream()).thenReturn(targetStream);
+        } catch (IOException e) {
+            fail(e);
+        }
+        VaadinResponse response = mock(VaadinResponse.class);
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        boolean handled = handler.synchronizedHandleRequest(session, request,
+                response);
+
+        assertTrue(handled);
+        verify(response).setStatus(400);
+    }
+
+    @Test
+    public void synchronizedHandleRequest_tracesHandled() {
+        VaadinSession session = mock(VaadinSession.class);
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getContentType()).thenReturn("application/json");
+        try {
+            // @formatter:off
+            InputStream targetStream = new ByteArrayInputStream("{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"unknown_service\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"webjs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.9.0\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"@opentelemetry/instrumentation-document-load\",\"version\":\"0.31.0\"},\"spans\":[{\"traceId\":\"b7e726b6155ac52912322123d2f31a2c\",\"spanId\":\"67279b5c43e6874c\",\"name\":\"documentLoad\",\"kind\":1,\"startTimeUnixNano\":1674542404352000000,\"endTimeUnixNano\":1674542405301000200,\"attributes\":[{\"key\":\"component\",\"value\":{\"stringValue\":\"document-load\"}},{\"key\":\"http.url\",\"value\":{\"stringValue\":\"http://localhost:8080/login\"}},{\"key\":\"http.user_agent\",\"value\":{\"stringValue\":\"Mozilla/5.0(WindowsNT10.0;Win64;x64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/109.0.0.0Safari/537.36\"}}],\"droppedAttributesCount\":0,\"events\":[{\"attributes\":[],\"name\":\"fetchStart\",\"timeUnixNano\":1674542404352000000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"unloadEventStart\",\"timeUnixNano\":1674542404385100000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"unloadEventEnd\",\"timeUnixNano\":1674542404385700000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domInteractive\",\"timeUnixNano\":1674542404468400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domContentLoadedEventStart\",\"timeUnixNano\":1674542405284400000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domContentLoadedEventEnd\",\"timeUnixNano\":1674542405287600000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"domComplete\",\"timeUnixNano\":1674542405293900000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"loadEventStart\",\"timeUnixNano\":1674542405300900000,\"droppedAttributesCount\":0},{\"attributes\":[],\"name\":\"loadEventEnd\",\"timeUnixNano\":1674542405301000200,\"droppedAttributesCount\":0}],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}".getBytes());
+            // @formatter:on
+            when(request.getInputStream()).thenReturn(targetStream);
+        } catch (IOException e) {
+            fail(e);
+        }
+        VaadinResponse response = mock(VaadinResponse.class);
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        boolean handled = handler.synchronizedHandleRequest(session, request,
+                response);
+
+        assertTrue(handled);
+        verify(response).setStatus(200);
+    }
+}

--- a/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityHandlerTest.java
+++ b/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityHandlerTest.java
@@ -13,8 +13,8 @@ import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.ApplicationConstants;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,7 +32,7 @@ public class ObservabilityHandlerTest {
 
         ObservabilityHandler.ensureInstalled(ui);
 
-        verify(session).addRequestHandler(any());
+        verify(session).addRequestHandler(any(ObservabilityHandler.class));
     }
 
     @Test
@@ -43,19 +43,28 @@ public class ObservabilityHandlerTest {
 
         ObservabilityHandler handler = ObservabilityHandler.ensureInstalled(ui);
 
-        verify(session).addRequestHandler(any());
+        verify(session).addRequestHandler(any(ObservabilityHandler.class));
 
         ObservabilityHandler handler1 = ObservabilityHandler
                 .ensureInstalled(ui);
 
         verifyNoMoreInteractions(session);
-        assertEquals(handler, handler1);
+        assertSame(handler, handler1);
+    }
+
+    @Test
+    public void canHandleRequest_emptyPath_returnsFalse() {
+        VaadinRequest request = mock(VaadinRequest.class);
+        when(request.getPathInfo()).thenReturn("");
+
+        ObservabilityHandler handler = new ObservabilityHandler();
+        assertFalse(handler.canHandleRequest(request));
     }
 
     @Test
     public void canHandleRequest_invalidPath_returnsFalse() {
         VaadinRequest request = mock(VaadinRequest.class);
-        when(request.getPathInfo()).thenReturn("");
+        when(request.getPathInfo()).thenReturn("/foo");
 
         ObservabilityHandler handler = new ObservabilityHandler();
         assertFalse(handler.canHandleRequest(request));

--- a/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityServiceInitListenerTest.java
+++ b/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityServiceInitListenerTest.java
@@ -15,7 +15,7 @@ import com.vaadin.flow.server.VaadinSession;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -48,12 +48,12 @@ public class ObservabilityServiceInitListenerTest {
 
         service.fireUIInitListeners(ui);
 
-        verify(session).addRequestHandler(any());
+        verify(session).addRequestHandler(any(ObservabilityHandler.class));
         verify(ui).add(any(ObservabilityClient.class));
     }
 
     @Test
-    public void serviceInit_clientExists_clientNotInstalled() {
+    public void serviceInit_clientExists_removesExistingClients() {
         ServiceInitEvent serviceInitEvent = mock(ServiceInitEvent.class);
         VaadinService service = mock(VaadinService.class);
         ArgumentCaptor<UIInitListener> listenerArgument = ArgumentCaptor
@@ -74,15 +74,16 @@ public class ObservabilityServiceInitListenerTest {
         verify(service).addUIInitListener(any());
 
         UI ui = mock(UI.class);
-        ObservabilityClient client = mock(ObservabilityClient.class);
-        when(ui.getChildren()).thenReturn(Stream.of(client));
+        ObservabilityClient client1 = new ObservabilityClient();
+        ObservabilityClient client2 = new ObservabilityClient();
+        when(ui.getChildren()).thenReturn(Stream.of(client1, client2));
         VaadinSession session = mock(VaadinSession.class);
         when(ui.getSession()).thenReturn(session);
 
         service.fireUIInitListeners(ui);
 
-        verify(session).addRequestHandler(any());
-        verify(ui).remove(any(ObservabilityClient.class));
-        verify(ui, never()).add(any(ObservabilityClient.class));
+        verify(session).addRequestHandler(any(ObservabilityHandler.class));
+        verify(ui, times(2)).remove(any(ObservabilityClient.class));
+        verify(ui).add(any(ObservabilityClient.class));
     }
 }

--- a/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityServiceInitListenerTest.java
+++ b/observability-kit-starter/src/test/java/com/vaadin/observability/ObservabilityServiceInitListenerTest.java
@@ -1,0 +1,88 @@
+package com.vaadin.observability;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.UIInitEvent;
+import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ObservabilityServiceInitListenerTest {
+    @Test
+    public void serviceInit_handlerAndClientInstalled() {
+        ServiceInitEvent serviceInitEvent = mock(ServiceInitEvent.class);
+        VaadinService service = mock(VaadinService.class);
+        ArgumentCaptor<UIInitListener> listenerArgument = ArgumentCaptor
+                .forClass(UIInitListener.class);
+        when(service.addUIInitListener(listenerArgument.capture()))
+                .thenReturn(null);
+        doAnswer(invocation -> {
+            UI ui = invocation.getArgument(0);
+            UIInitEvent uiInitEvent = new UIInitEvent(ui, service);
+            listenerArgument.getValue().uiInit(uiInitEvent);
+            return null;
+        }).when(service).fireUIInitListeners(any());
+        when(serviceInitEvent.getSource()).thenReturn(service);
+
+        ObservabilityServiceInitListener listener = new ObservabilityServiceInitListener();
+        listener.serviceInit(serviceInitEvent);
+
+        verify(service).addUIInitListener(any());
+
+        UI ui = mock(UI.class);
+        when(ui.getChildren()).thenReturn(Stream.empty());
+        VaadinSession session = mock(VaadinSession.class);
+        when(ui.getSession()).thenReturn(session);
+
+        service.fireUIInitListeners(ui);
+
+        verify(session).addRequestHandler(any());
+        verify(ui).add(any(ObservabilityClient.class));
+    }
+
+    @Test
+    public void serviceInit_clientExists_clientNotInstalled() {
+        ServiceInitEvent serviceInitEvent = mock(ServiceInitEvent.class);
+        VaadinService service = mock(VaadinService.class);
+        ArgumentCaptor<UIInitListener> listenerArgument = ArgumentCaptor
+                .forClass(UIInitListener.class);
+        when(service.addUIInitListener(listenerArgument.capture()))
+                .thenReturn(null);
+        doAnswer(invocation -> {
+            UI ui = invocation.getArgument(0);
+            UIInitEvent uiInitEvent = new UIInitEvent(ui, service);
+            listenerArgument.getValue().uiInit(uiInitEvent);
+            return null;
+        }).when(service).fireUIInitListeners(any());
+        when(serviceInitEvent.getSource()).thenReturn(service);
+
+        ObservabilityServiceInitListener listener = new ObservabilityServiceInitListener();
+        listener.serviceInit(serviceInitEvent);
+
+        verify(service).addUIInitListener(any());
+
+        UI ui = mock(UI.class);
+        ObservabilityClient client = mock(ObservabilityClient.class);
+        when(ui.getChildren()).thenReturn(Stream.of(client));
+        VaadinSession session = mock(VaadinSession.class);
+        when(ui.getSession()).thenReturn(session);
+
+        service.fireUIInitListeners(ui);
+
+        verify(session).addRequestHandler(any());
+        verify(ui).remove(any(ObservabilityClient.class));
+        verify(ui, never()).add(any(ObservabilityClient.class));
+    }
+}

--- a/observability-kit-starter/tsconfig.json
+++ b/observability-kit-starter/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true,
+    "module": "esNext",
+    "target": "es2019",
+    "moduleResolution": "node",
+    "strict": true,
+    "skipDefaultLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "experimentalDecorators": true,
+    "baseUrl": "frontend",
+    "paths": {
+      "Frontend/*": [
+        "*"
+      ]
+    }
+  },
+  "include": [
+    "src/main/resources/META-INF/resources/frontend/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <flow.version>24.0-SNAPSHOT</flow.version>
         <servlet.api.version>6.0.0</servlet.api.version>
-        <opentelemetry.version>1.22.0</opentelemetry.version>
+        <opentelemetry.version>1.23.0</opentelemetry.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.shade.version>3.4.1</maven.shade.version>
         <maven.source.version>3.2.1</maven.source.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
     <modules>
         <module>observability-kit-agent</module>
+        <module>observability-kit-starter</module>
     </modules>
 
     <properties>
@@ -80,7 +81,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>1.10.1</version>
+                <version>1.11.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

This adds a Lit web component to each UI, which sets up the OpenTelemetry client-side instrumentation. Traces are then sent to  a request handler in the server. The agent adds hooks on the request handler and recreates the trace spans from the incoming data.

Fixes #149 

## Type of change

- [ ] Bugfix
- [x] Feature