### PR TITLE
chore: ignore maven temporary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .factorypath
 
 *pom.xml.versionsBackup
+dependency-reduced-pom.xml
 
 *.DS_Store
 .idea/


### PR DESCRIPTION
The dependency-reduced-pom.xml is generated by maven and used only during the build. It can be safely ignored in the code base.