### PR TITLE
chore: made disconnectedCallback public

### DIFF
--- a/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
+++ b/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
@@ -73,7 +73,7 @@ export class ObservabilityClient extends LitElement {
     });
   }
 
-  protected disconnectedCallback() {
+  disconnectedCallback() {
     super.disconnectedCallback();
 
     if (this.unloadInstrumentations) {


### PR DESCRIPTION
IDE complains about disconnectedCallback visibility

TS2415: Class 'ObservabilityClient' incorrectly extends base class 'LitElement'. Property 'disconnectedCallback' is protected in type 'ObservabilityClient' but public in type 'LitElement'.