### PR TITLE
fix: removed lit import

### DIFF
--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
@@ -5,7 +5,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 
-@NpmPackage(value = "lit", version = "")
 @NpmPackage(value = "@opentelemetry/sdk-trace-web", version = "1.8.0")
 @NpmPackage(value = "@opentelemetry/instrumentation", version = "0.35.0")
 @NpmPackage(value = "@opentelemetry/instrumentation-document-load", version = "0.31.0")


### PR DESCRIPTION
ObservabilityClient component import lit npm package without version and this makes the dev-bundle task fail.
Furthermore, it should not be necessary to add the lit dependency as it is already pin by Flow
