### PR TITLE
chore: exclude the demo and test modules when release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,22 @@
     <modules>
         <module>observability-kit-agent</module>
         <module>observability-kit-starter</module>
-        <module>observability-kit-test</module>
-        <module>observability-kit-demo</module>
     </modules>
+    
+    <profiles>
+        <profile>
+            <id>test</id>
+            <activation>
+                <property>
+                    <name>!release</name>
+                </property>
+            <activation>
+                <modules>
+                    <module>observability-kit-test</module>
+                    <module>observability-kit-demo</module>
+                </modules>
+        </profile>
+    </profiles>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -222,4 +235,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>


### PR DESCRIPTION
these two module can deactivated by calling `-Drelease` 