### PR TITLE
fix: added missing annotation api dependency

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -25,6 +25,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${annotation.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>${flow.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <flow.version>24.0-SNAPSHOT</flow.version>
         <servlet.api.version>6.0.0</servlet.api.version>
+        <annotation.api.version>2.1.1</annotation.api.version>
         <opentelemetry.version>1.23.0</opentelemetry.version>
         <jetty.version>11.0.13</jetty.version>
         <junit.version>5.9.2</junit.version>


### PR DESCRIPTION
## Description

The dependency was previously probably transitively provided by Flow, perhaps from websocket apis whose scope has changed to provided.
This change adds an explicit dependency to the jakarta annotation package.

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
