### PR TITLE
test: reduced verbosity of mock server

### DIFF
--- a/observability-kit-test/observability-kit-agent-it/pom.xml
+++ b/observability-kit-test/observability-kit-agent-it/pom.xml
@@ -16,6 +16,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <otel.exporter>otlp</otel.exporter>
         <otel.debug>false</otel.debug>
+        <mockserver.logLevel>WARN</mockserver.logLevel>
     </properties>
 
     <dependencies>
@@ -182,6 +183,9 @@
                         <configuration>
                             <trimStackTrace>false</trimStackTrace>
                             <enableAssertions>true</enableAssertions>
+                            <systemPropertyVariables>
+                                <mockserver.logLevel>${mockserver.logLevel}</mockserver.logLevel>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Mock server produces a huge amount of log messages that are not useful in the context of observability tests.
This change adds a system parameter to the maven failsafe plugin configuration to set the log level for mock server to WARN, in order to get only severe messages.
The log level can be changed setting the 'mockserver.logLevel' system property in the maven command line
