### PR TITLE
Prevent spans from being created by frontend trace requests

### DIFF
--- a/observability-kit-agent/src/main/java/com/vaadin/extension/Constants.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/Constants.java
@@ -23,4 +23,7 @@ public class Constants {
 
     public static final String REQUEST_LOCATION_PARAMETER = "location";
     public static final String FRONTEND_ID = "vaadin.frontend.id";
+    public static final String REQUEST_TYPE_OBSERVABILITY = "o11y";
+    public static final String REQUEST_TYPE_HEARTBEAT = "heartbeat";
+
 }

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.RouteConfiguration;
-import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.Version;
 import com.vaadin.flow.shared.ApplicationConstants;
 
@@ -382,8 +381,8 @@ public class InstrumentationHelper {
     }
 
     public static boolean isRequestType(HttpServletRequest servletRequest,
-            HandlerHelper.RequestType requestType) {
-        return requestType.getIdentifier().equals(servletRequest
-                .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER));
+            String requestType) {
+        return requestType.equals(servletRequest.getParameter
+                (ApplicationConstants.REQUEST_TYPE_PARAMETER));
     }
 }

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/server/VaadinServletInstrumentation.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/server/VaadinServletInstrumentation.java
@@ -13,10 +13,10 @@ import static io.opentelemetry.javaagent.extension.matcher.AgentElementMatchers.
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
+import com.vaadin.extension.Constants;
 import com.vaadin.extension.InstrumentationHelper;
 import com.vaadin.extension.conf.Configuration;
 import com.vaadin.extension.conf.TraceLevel;
-import com.vaadin.flow.server.HandlerHelper;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -65,8 +65,12 @@ public class VaadinServletInstrumentation implements TypeInstrumentation {
                 @Advice.Local("rootSpanCreated") boolean rootSpanCreated) {
             rootSpanCreated = false;
             if (InstrumentationHelper.isRequestType(servletRequest,
-                    HandlerHelper.RequestType.HEARTBEAT)
-                    && !Configuration.isEnabled(TraceLevel.MAXIMUM)) {
+                    Constants.REQUEST_TYPE_HEARTBEAT) &&
+                            !Configuration.isEnabled(TraceLevel.MAXIMUM)) {
+                return;
+            }
+            if (InstrumentationHelper.isRequestType(servletRequest,
+                    Constants.REQUEST_TYPE_OBSERVABILITY)) {
                 return;
             }
             // Create a server root span if it doesn't exist yet. This can be

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/SessionRequestHandlerInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/SessionRequestHandlerInstrumentationTest.java
@@ -1,9 +1,13 @@
 package com.vaadin.extension.instrumentation.communication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
+import com.vaadin.extension.Constants;
 import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
+import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.communication.SessionRequestHandler;
+import com.vaadin.flow.shared.ApplicationConstants;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,17 +16,20 @@ import org.mockito.Mockito;
 
 public class SessionRequestHandlerInstrumentationTest
         extends AbstractInstrumentationTest {
+    private VaadinRequest request;
     private SessionRequestHandler sessionRequestHandlerMock;
 
     @BeforeEach
     public void setup() {
+        request = Mockito.mock(VaadinRequest.class);
         sessionRequestHandlerMock = Mockito.mock(SessionRequestHandler.class);
     }
 
     @Test
     public void handleRequest_createsSpan() {
         SessionRequestHandlerInstrumentation.HandleRequestAdvice.onEnter(
-                sessionRequestHandlerMock, "handleRequest", null, null);
+                request, sessionRequestHandlerMock, "handleRequest",
+                null, null);
         SessionRequestHandlerInstrumentation.HandleRequestAdvice.onExit(null,
                 true, getCapturedSpan(0), null);
 
@@ -31,9 +38,25 @@ public class SessionRequestHandlerInstrumentationTest
     }
 
     @Test
+    public void handleRequest_observabilityRequest_noSpanCreated() {
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn(Constants.REQUEST_TYPE_OBSERVABILITY);
+
+        SessionRequestHandlerInstrumentation.HandleRequestAdvice.onEnter(
+                request, sessionRequestHandlerMock, "handleRequest",
+                null, null);
+        SessionRequestHandlerInstrumentation.HandleRequestAdvice.onExit(null,
+                true, null, null);
+
+        assertEquals(0, getExportedSpanCount(),
+                "No span should be made for observability");
+    }
+
+    @Test
     public void handleRequestWithException_setsErrorStatus() {
         SessionRequestHandlerInstrumentation.HandleRequestAdvice.onEnter(
-                sessionRequestHandlerMock, "handleRequest", null, null);
+                request, sessionRequestHandlerMock, "handleRequest",
+                null, null);
         Exception exception = new RuntimeException("test error");
         SessionRequestHandlerInstrumentation.HandleRequestAdvice
                 .onExit(exception, true, getCapturedSpan(0), null);

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/server/VaadinServletInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/server/VaadinServletInstrumentationTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.vaadin.extension.HttpStatusCode;
 import com.vaadin.extension.conf.TraceLevel;
 import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
-import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -119,8 +118,7 @@ class VaadinServletInstrumentationTest extends AbstractInstrumentationTest {
     public void heartbeatRequest_byDefaultNoSpan() {
         Mockito.when(servletRequest
                 .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
-                .thenReturn(
-                        HandlerHelper.RequestType.HEARTBEAT.getIdentifier());
+                .thenReturn(REQUEST_TYPE_HEARTBEAT);
 
         VaadinServletInstrumentation.MethodAdvice.onEnter(servletRequest, null,
                 null, false);
@@ -135,8 +133,7 @@ class VaadinServletInstrumentationTest extends AbstractInstrumentationTest {
     public void heartbeatRequest_maxTrace_spanCreated() {
         Mockito.when(servletRequest
                 .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
-                .thenReturn(
-                        HandlerHelper.RequestType.HEARTBEAT.getIdentifier());
+                .thenReturn(REQUEST_TYPE_HEARTBEAT);
         configureTraceLevel(TraceLevel.MAXIMUM);
 
         VaadinServletInstrumentation.MethodAdvice.onEnter(servletRequest, null,
@@ -146,6 +143,21 @@ class VaadinServletInstrumentationTest extends AbstractInstrumentationTest {
 
         assertEquals(1, getExportedSpanCount(),
                 "Maximum trace should generate heartbeat");
+    }
+
+    @Test
+    public void observabilityRequest_noSpanCreated() {
+        Mockito.when(servletRequest
+                        .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn(REQUEST_TYPE_OBSERVABILITY);
+
+        VaadinServletInstrumentation.MethodAdvice.onEnter(servletRequest, null,
+                null, false);
+        VaadinServletInstrumentation.MethodAdvice.onExit(null, servletResponse,
+                currentContext(), currentContext().makeCurrent(), false);
+
+        assertEquals(0, getExportedSpanCount(),
+                "No span should be made for observability");
     }
 
     @Test

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/ObservabilityClient.java
@@ -12,7 +12,6 @@ package com.vaadin.observability;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;

--- a/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
+++ b/observability-kit-starter/src/main/resources/META-INF/resources/frontend/components/observability-client.ts
@@ -37,7 +37,7 @@ export class ObservabilityClient extends LitElement {
   traceDocumentLoad?: boolean;
   traceUserInteraction?: EventName[]
   traceXmlHTTPRequest?: boolean;
-  ignoreURLs?: string[];
+  ignoredURLs?: string[];
   ignoreVaadinURLs?: boolean;
 
   traceLongTask?: boolean;
@@ -102,10 +102,11 @@ export class ObservabilityClient extends LitElement {
         ignoredUrls.push(/\/?v-r=.*/);
         ignoredUrls.push(/\/VAADIN\/.*/);
       } else {
-        ignoredUrls.push('/?v-r=o11y');
+        ignoredUrls.push(/v-r=heartbeat/);
+        ignoredUrls.push(/v-r=o11y/);
       }
-      if (this.ignoreURLs) {
-        ignoredUrls.push(...this.ignoreURLs.map((url) => {
+      if (this.ignoredURLs) {
+        ignoredUrls.push(...this.ignoredURLs.map((url) => {
           const match = url.match(/^RE:\/(.*)\/$/);
           if (match) {
             return new RegExp(match[1]);


### PR DESCRIPTION
## Description

This ensures that the frontend trace requests do not create a span on the server-side instrumentation. In addition, heartbeat requests are ignored by the frontend instrumentation.

Fixes #201 

## Type of change

- [X] Bugfix
- [ ] Feature