### PR TITLE
Add explicit byte buddy dependency

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <extension.name>opentelemetry-vaadin-observability-instrumentation-extension</extension.name>
         <google.auto-service.version>1.0</google.auto-service.version>
-        <byte-buddy.plugin.version>1.13.0</byte-buddy.plugin.version>
+        <byte-buddy.version>1.14.4</byte-buddy.version>
     </properties>
 
     <dependencies>
@@ -46,6 +46,12 @@
             <artifactId>auto-service</artifactId>
             <version>${google.auto-service.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byte-buddy.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
@@ -101,7 +107,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.7.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -151,7 +157,7 @@
             <plugin>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-maven-plugin</artifactId>
-                <version>${byte-buddy.plugin.version}</version>
+                <version>${byte-buddy.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>io.opentelemetry.javaagent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <module>observability-kit-agent</module>
         <module>observability-kit-starter</module>
     </modules>
-    
+
     <profiles>
         <profile>
             <id>test</id>
@@ -50,7 +50,7 @@
         <opentelemetry.version>1.23.0</opentelemetry.version>
         <jetty.version>11.0.13</jetty.version>
         <junit.version>5.9.2</junit.version>
-        <mockito.version>4.8.1</mockito.version>
+        <mockito.version>5.2.0</mockito.version>
         <testbench.version>9.0.2</testbench.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.war.version>3.3.2</maven.war.version>


### PR DESCRIPTION
## Description

The byte buddy dependency was previously added through the Flow server dependency. Now that has been removed, the Observability Kit agent requires an explicit dependency in order to make the tests run.

Fixes #209 