### PR TITLE
Use dev.hilla:endpoint dependency also in the agent module

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>dev.hilla</groupId>
-            <artifactId>hilla</artifactId>
+            <artifactId>endpoint</artifactId>
             <version>${hilla.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Also the agent module needs to depend on the `dev.hilla:endpoint` artifact.