### PR TITLE
Add license checking to the Hilla frontend module

### DIFF
--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -21,6 +21,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${servlet.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>${flow.version}</version>

--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -51,6 +51,12 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -31,6 +31,10 @@
             <version>${hilla.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/observability-kit-starter-hilla/src/main/java/dev/hilla/observability/LicenseCheckerServiceInitListener.java
+++ b/observability-kit-starter-hilla/src/main/java/dev/hilla/observability/LicenseCheckerServiceInitListener.java
@@ -1,0 +1,49 @@
+package dev.hilla.observability;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+public class LicenseCheckerServiceInitListener
+        implements VaadinServiceInitListener {
+
+    static final String PROPERTIES_RESOURCE = "observability-kit.properties";
+
+    static final String VERSION_PROPERTY = "observability-kit.version";
+
+    static final String PRODUCT_NAME = "hilla-observability-kit";
+
+    @Override
+    public void serviceInit(ServiceInitEvent serviceInitEvent) {
+        final var service = serviceInitEvent.getSource();
+        final var properties = loadAllProperties(PROPERTIES_RESOURCE);
+        final var version = properties.getProperty(VERSION_PROPERTY);
+
+        UsageStatistics.markAsUsed(PRODUCT_NAME, version);
+
+        // Check the license at runtime if in development mode
+        if (!service.getDeploymentConfiguration().isProductionMode()) {
+            // Using a null BuildType to allow trial licensing builds
+            // The variable is defined to avoid method signature ambiguity
+            BuildType buildType = null;
+            LicenseChecker.checkLicense(PRODUCT_NAME, version, buildType);
+        }
+    }
+
+
+    static Properties loadAllProperties(String propertiesResource) {
+        final var cl = LicenseCheckerServiceInitListener.class.getClassLoader();
+        try (final var stream = cl.getResourceAsStream(propertiesResource)) {
+            final var properties = new Properties();
+            properties.load(stream);
+            return properties;
+        } catch (NullPointerException | IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/observability-kit-starter-hilla/src/main/java/dev/hilla/observability/ObservabilityEndpoint.java
+++ b/observability-kit-starter-hilla/src/main/java/dev/hilla/observability/ObservabilityEndpoint.java
@@ -7,7 +7,7 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
-package com.vaadin.observability;
+package dev.hilla.observability;
 
 import java.io.IOException;
 import java.nio.charset.Charset;

--- a/observability-kit-starter-hilla/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/observability-kit-starter-hilla/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+dev.hilla.observability.LicenseCheckerServiceInitListener

--- a/observability-kit-starter-hilla/src/main/resources/observability-kit.properties
+++ b/observability-kit-starter-hilla/src/main/resources/observability-kit.properties
@@ -1,0 +1,1 @@
+observability-kit.version=${project.version}

--- a/observability-kit-starter-hilla/src/test/java/com/vaadin/observability/ObservabilityEndpointTest.java
+++ b/observability-kit-starter-hilla/src/test/java/com/vaadin/observability/ObservabilityEndpointTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.observability;
 
 import dev.hilla.exception.EndpointException;
+import dev.hilla.observability.ObservabilityEndpoint;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/observability-kit-starter-hilla/src/test/java/dev/hilla/observability/LicenseCheckerServiceInitListenerTest.java
+++ b/observability-kit-starter-hilla/src/test/java/dev/hilla/observability/LicenseCheckerServiceInitListenerTest.java
@@ -1,0 +1,91 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package dev.hilla.observability;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+import static dev.hilla.observability.LicenseCheckerServiceInitListener.loadAllProperties;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseCheckerServiceInitListenerTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private VaadinService service;
+
+    private MockedStatic<LicenseChecker> licenseChecker;
+
+    @BeforeEach
+    public void setup() {
+        licenseChecker = mockStatic(LicenseChecker.class);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        licenseChecker.close();
+    }
+
+    @Test
+    public void developmentMode_licenseIsCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(false);
+
+        final var properties = loadAllProperties(LicenseCheckerServiceInitListener.PROPERTIES_RESOURCE);
+
+        final var version = properties.getProperty(
+                LicenseCheckerServiceInitListener.VERSION_PROPERTY);
+
+        // Assert version is in X.Y format
+        assertThat(version, matchesPattern("^\\d\\.\\d.*"));
+
+        final var listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        // Verify the license is checked
+        BuildType buildType = null;
+        licenseChecker.verify(() -> LicenseChecker.checkLicense(
+                LicenseCheckerServiceInitListener.PRODUCT_NAME, version,
+                buildType));
+    }
+
+    @Test
+    public void productionMode_licenseIsNotCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(true);
+
+        final var listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        licenseChecker.verifyNoInteractions();
+    }
+
+    @Test
+    public void serviceInit_throwsError_whenPropertiesLoadFails() {
+        assertThrows(ExceptionInInitializerError.class, () -> {
+            LicenseCheckerServiceInitListener.loadAllProperties("non-existent");
+        });
+    }
+}

--- a/observability-kit-starter-hilla/src/test/java/dev/hilla/observability/ObservabilityEndpointTest.java
+++ b/observability-kit-starter-hilla/src/test/java/dev/hilla/observability/ObservabilityEndpointTest.java
@@ -1,4 +1,4 @@
-package com.vaadin.observability;
+package dev.hilla.observability;
 
 import dev.hilla.exception.EndpointException;
 import dev.hilla.observability.ObservabilityEndpoint;


### PR DESCRIPTION
This adds license checking to the Hilla frontend module adding a service-init listener that calls the `LicenseChecker` when in development mode. For production, the license is checked at build time.

This also rename the Hilla frontend module package name from ~`com.vaadin.observability`~ to `dev.hilla.observability`.