### PR TITLE
chore: remove unnecessary dependency blocks and set deps as provided

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -31,12 +31,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-server</artifactId>
-            <version>${flow.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-data</artifactId>
             <version>${flow.version}</version>
             <scope>provided</scope>

--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -30,6 +30,7 @@
             <groupId>dev.hilla</groupId>
             <artifactId>endpoint</artifactId>
             <version>${hilla.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -27,11 +27,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>flow-server</artifactId>
-            <version>${flow.version}</version>
-        </dependency>
-        <dependency>
             <groupId>dev.hilla</groupId>
             <artifactId>endpoint</artifactId>
             <version>${hilla.version}</version>

--- a/observability-kit-starter/pom.xml
+++ b/observability-kit-starter/pom.xml
@@ -29,6 +29,7 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>${flow.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,14 @@
     </profiles>
 
     <properties>
+        <flow.version>24.2-SNAPSHOT</flow.version>
+        <hilla.version>2.2-SNAPSHOT</hilla.version>
+        <vaadin.license.checker.version>1.12.0</vaadin.license.checker.version>
+
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <flow.version>24.2-SNAPSHOT</flow.version>
-        <hilla.version>2.2-SNAPSHOT</hilla.version>
         <servlet.api.version>6.0.0</servlet.api.version>
         <annotation.api.version>2.1.1</annotation.api.version>
         <opentelemetry.version>1.23.0</opentelemetry.version>
@@ -143,7 +145,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>1.12.0</version>
+                <version>${vaadin.license.checker.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This fixes the fact that in hilla starter we dont have an incorrect version of the flow-server, as well as we can bump versions of vaadin or hilla in our project without having conflicts