### PR TITLE
Bump to 3.0 for V24.4

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>observability-kit</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>observability-kit-agent</artifactId>

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
@@ -58,7 +58,7 @@ import java.util.Set;
 
 public class InstrumentationHelper {
     public static final String INSTRUMENTATION_NAME = "com.vaadin.observability.instrumentation";
-    public static final String INSTRUMENTATION_VERSION = "2.2";
+    public static final String INSTRUMENTATION_VERSION = "3.0";
 
     private static final SpanNameGenerator generator = new SpanNameGenerator();
     private static final SpanAttributeGenerator attrGet = new SpanAttributeGenerator();

--- a/observability-kit-demo-hilla/pom.xml
+++ b/observability-kit-demo-hilla/pom.xml
@@ -3,17 +3,16 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <!-- Project from https://start.vaadin.com/ -->
-    <groupId>dev.hilla</groupId>
-    <artifactId>observability-kit-demo-hilla</artifactId>
-    <name>Observability Kit demo application for Hilla</name>
-    <packaging>jar</packaging>
 
     <parent>
         <artifactId>observability-kit</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
+
+    <groupId>com.vaadin.hilla</groupId>
+    <artifactId>observability-kit-demo-hilla</artifactId>
+    <name>Observability Kit demo application for Hilla</name>
 
     <properties>
         <java.version>17</java.version>
@@ -40,7 +39,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>dev.hilla</groupId>
+                <groupId>com.vaadin.hilla</groupId>
                 <artifactId>hilla-bom</artifactId>
                 <version>${hilla.version}</version>
                 <type>pom</type>
@@ -49,7 +48,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.0.5</version>
+                <version>3.2.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -58,19 +57,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>dev.hilla</groupId>
+            <groupId>com.vaadin.hilla</groupId>
             <artifactId>hilla</artifactId>
         </dependency>
         <dependency>
-            <groupId>dev.hilla</groupId>
+            <groupId>com.vaadin.hilla</groupId>
             <artifactId>hilla-spring-boot-starter</artifactId>
+            <version>${hilla.version}</version>
         </dependency>
         <dependency>
             <groupId>org.parttio</groupId>
             <artifactId>line-awesome</artifactId>
             <version>1.1.0</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
@@ -112,7 +111,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>dev.hilla</groupId>
+            <groupId>com.vaadin.hilla</groupId>
             <artifactId>observability-kit-starter</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/observability-kit-demo-hilla/src/main/java/com/example/application/hilla/endpoints/helloworld/HelloWorldEndpoint.java
+++ b/observability-kit-demo-hilla/src/main/java/com/example/application/hilla/endpoints/helloworld/HelloWorldEndpoint.java
@@ -1,7 +1,7 @@
 package com.example.application.hilla.endpoints.helloworld;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;
-import dev.hilla.Endpoint;
+import com.vaadin.hilla.Endpoint;
 
 @Endpoint
 @AnonymousAllowed

--- a/observability-kit-demo-hilla/src/main/java/com/example/application/hilla/endpoints/user/UserEndpoint.java
+++ b/observability-kit-demo-hilla/src/main/java/com/example/application/hilla/endpoints/user/UserEndpoint.java
@@ -9,7 +9,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.spring.security.AuthenticationContext;
-import dev.hilla.Endpoint;
+import com.vaadin.hilla.Endpoint;
 
 @Endpoint
 @AnonymousAllowed

--- a/observability-kit-demo/pom.xml
+++ b/observability-kit-demo/pom.xml
@@ -3,18 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>observability-kit</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>observability-kit-demo</artifactId>
     <name>Observability Kit demo application</name>
     <description>
         A Vaadin application that contains slowness, errors and other bugs that can be spotted using
         the Vaadin Observability Kit.
     </description>
-    <packaging>jar</packaging>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -77,7 +78,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.0.2</version>
+                <version>3.2.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -3,13 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>observability-kit</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>dev.hilla</groupId>
+    <groupId>com.vaadin.hilla</groupId>
     <artifactId>observability-kit-starter</artifactId>
 
     <properties>
@@ -27,7 +28,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>dev.hilla</groupId>
+            <groupId>com.vaadin.hilla</groupId>
             <artifactId>endpoint</artifactId>
             <version>${hilla.version}</version>
             <scope>provided</scope>

--- a/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/LicenseCheckerServiceInitListener.java
+++ b/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/LicenseCheckerServiceInitListener.java
@@ -1,4 +1,13 @@
-package dev.hilla.observability;
+/*-
+ * Copyright (C) 2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.hilla.observability;
 
 import java.io.IOException;
 import java.util.Properties;

--- a/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/ObservabilityEndpoint.java
+++ b/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/ObservabilityEndpoint.java
@@ -1,5 +1,5 @@
 /*-
- * Copyright (C) 2022 Vaadin Ltd
+ * Copyright (C) 2024 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -7,21 +7,19 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
-package dev.hilla.observability;
+package com.vaadin.hilla.observability;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import com.vaadin.flow.server.auth.AnonymousAllowed;
-
-import dev.hilla.Endpoint;
-import dev.hilla.exception.EndpointException;
+import com.vaadin.hilla.Endpoint;
+import com.vaadin.hilla.exception.EndpointException;
 
 @Endpoint
 @AnonymousAllowed

--- a/observability-kit-starter-hilla/src/test/java/com/vaadin/hilla/observability/LicenseCheckerServiceInitListenerTest.java
+++ b/observability-kit-starter-hilla/src/test/java/com/vaadin/hilla/observability/LicenseCheckerServiceInitListenerTest.java
@@ -1,5 +1,5 @@
 /*-
- * Copyright (C) 2022 Vaadin Ltd
+ * Copyright (C) 2024 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
@@ -7,7 +7,7 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
-package dev.hilla.observability;
+package com.vaadin.hilla.observability;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +23,7 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.pro.licensechecker.BuildType;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 
-import static dev.hilla.observability.LicenseCheckerServiceInitListener.loadAllProperties;
+import static com.vaadin.hilla.observability.LicenseCheckerServiceInitListener.loadAllProperties;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/observability-kit-starter-hilla/src/test/java/com/vaadin/hilla/observability/ObservabilityEndpointTest.java
+++ b/observability-kit-starter-hilla/src/test/java/com/vaadin/hilla/observability/ObservabilityEndpointTest.java
@@ -1,8 +1,17 @@
-package dev.hilla.observability;
+/*-
+ * Copyright (C) 2024 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.hilla.observability;
 
-import dev.hilla.exception.EndpointException;
-import dev.hilla.observability.ObservabilityEndpoint;
 import org.junit.jupiter.api.Test;
+
+import com.vaadin.hilla.exception.EndpointException;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/observability-kit-starter/pom.xml
+++ b/observability-kit-starter/pom.xml
@@ -2,12 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>observability-kit</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>observability-kit-starter</artifactId>
 

--- a/observability-kit-test/observability-kit-agent-it/pom.xml
+++ b/observability-kit-test/observability-kit-agent-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>observability-kit-test</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>observability-kit-agent-it</artifactId>

--- a/observability-kit-test/pom.xml
+++ b/observability-kit-test/pom.xml
@@ -1,12 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>observability-kit</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>observability-kit-test</artifactId>
     <packaging>pom</packaging>
+
     <modules>
         <module>observability-kit-agent-it</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>observability-kit</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <licenses>
@@ -52,9 +52,9 @@
     </profiles>
 
     <properties>
-        <flow.version>24.2-SNAPSHOT</flow.version>
-        <hilla.version>2.2-SNAPSHOT</hilla.version>
-        <vaadin.license.checker.version>1.12.3</vaadin.license.checker.version>
+        <flow.version>24.4-SNAPSHOT</flow.version>
+        <hilla.version>24.4-SNAPSHOT</hilla.version>
+        <vaadin.license.checker.version>1.12.7</vaadin.license.checker.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -66,7 +66,7 @@
         <jetty.version>11.0.13</jetty.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.2.0</mockito.version>
-        <testbench.version>9.1.0</testbench.version>
+        <testbench.version>9.2.2</testbench.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.war.version>3.3.2</maven.war.version>
         <maven.shade.version>3.4.1</maven.shade.version>


### PR DESCRIPTION
This bumps the kit to version 3.0 that includes the Hilla package and namespace rename.

Before releasing, special care needs to be taken on the build workflow when publishing NPM packages that now belongs to the @vaadin namespace and not the @hilla namespace.