### PR TITLE
Rename Hilla groupId

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -36,8 +36,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.vaadin.hilla</groupId>
-            <artifactId>endpoint</artifactId>
+            <groupId>com.vaadin</groupId>
+            <artifactId>hilla-endpoint</artifactId>
             <version>${hilla.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/observability-kit-demo-hilla/package.json
+++ b/observability-kit-demo-hilla/package.json
@@ -80,7 +80,13 @@
     "@vaadin/virtual-list": "24.4.0-alpha13",
     "construct-style-sheets-polyfill": "3.1.0",
     "date-fns": "2.29.3",
-    "lit": "3.1.2"
+    "lit": "3.1.2",
+    "react-dom": "18.2.0",
+    "@vaadin/hilla-react-auth": "24.4.0-alpha4",
+    "react-router-dom": "6.22.0",
+    "react": "18.2.0",
+    "@vaadin/hilla-react-crud": "24.4.0-alpha4",
+    "@vaadin/hilla-react-form": "24.4.0-alpha4"
   },
   "devDependencies": {
     "@babel/preset-react": "^7",
@@ -108,7 +114,9 @@
     "vite-plugin-checker": "0.6.4",
     "workbox-build": "7.0.0",
     "workbox-core": "7.0.0",
-    "workbox-precaching": "7.0.0"
+    "workbox-precaching": "7.0.0",
+    "@types/react-dom": "18.2.19",
+    "@types/react": "18.2.55"
   },
   "vaadin": {
     "dependencies": {
@@ -189,7 +197,13 @@
       "@vaadin/virtual-list": "24.4.0-alpha13",
       "construct-style-sheets-polyfill": "3.1.0",
       "date-fns": "2.29.3",
-      "lit": "3.1.2"
+      "lit": "3.1.2",
+      "react-dom": "18.2.0",
+      "@vaadin/hilla-react-auth": "24.4.0-alpha4",
+      "react-router-dom": "6.22.0",
+      "react": "18.2.0",
+      "@vaadin/hilla-react-crud": "24.4.0-alpha4",
+      "@vaadin/hilla-react-form": "24.4.0-alpha4"
     },
     "devDependencies": {
       "@babel/preset-react": "^7",
@@ -216,7 +230,9 @@
       "vite-plugin-checker": "0.6.4",
       "workbox-build": "7.0.0",
       "workbox-core": "7.0.0",
-      "workbox-precaching": "7.0.0"
+      "workbox-precaching": "7.0.0",
+      "@types/react-dom": "18.2.19",
+      "@types/react": "18.2.55"
     },
     "hash": "67a64739cf106a5bab34e44b4dac8ccd69a86b0b095feb75668efbc166764d1c"
   },

--- a/observability-kit-demo-hilla/pom.xml
+++ b/observability-kit-demo-hilla/pom.xml
@@ -10,7 +10,6 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.vaadin.hilla</groupId>
     <artifactId>observability-kit-demo-hilla</artifactId>
     <name>Observability Kit demo application for Hilla</name>
 
@@ -59,8 +58,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.vaadin.hilla</groupId>
-            <artifactId>observability-kit-starter</artifactId>
+            <groupId>com.vaadin</groupId>
+            <artifactId>observability-kit-starter-hilla</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -10,8 +10,7 @@
         <version>3.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.vaadin.hilla</groupId>
-    <artifactId>observability-kit-starter</artifactId>
+    <artifactId>observability-kit-starter-hilla</artifactId>
 
     <properties>
         <cvdl.name>hilla-observability-kit</cvdl.name>
@@ -28,8 +27,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.vaadin.hilla</groupId>
-            <artifactId>endpoint</artifactId>
+            <groupId>com.vaadin</groupId>
+            <artifactId>hilla-endpoint</artifactId>
             <version>${hilla.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
This renames the `groupId` for Hilla packages and also catches up with changes done in https://github.com/vaadin/hilla/commit/a9e0c36f94ae1412c1e2910bced7cc0c8001e229

Breaking changes:
- the kit starter for Hilla has been renamed from
  `com.vaadin.hilla:observability-kit-starter`
  to
  `com.vaadin:observability-kit-starter-hilla`

We might not even need a separate module for Hilla now.