### PR TITLE
Updated OpenTelemetry to 1.31.0 and ByteBuddy to 1.15.0

### DIFF
--- a/observability-kit-agent/pom.xml
+++ b/observability-kit-agent/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <extension.name>opentelemetry-vaadin-observability-instrumentation-extension</extension.name>
         <google.auto-service.version>1.0</google.auto-service.version>
-        <byte-buddy.version>1.14.4</byte-buddy.version>
+        <byte-buddy.version>1.15.0</byte-buddy.version>
     </properties>
 
     <dependencies>

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/InstrumentationHelper.java
@@ -14,12 +14,12 @@ import static com.vaadin.extension.Constants.REQUEST_TYPE;
 import static com.vaadin.extension.Constants.SESSION_ID;
 import static com.vaadin.flow.server.Constants.VAADIN_MAPPING;
 import static io.opentelemetry.javaagent.bootstrap.Java8BytecodeBridge.currentContext;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_HOST;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_METHOD;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_ROUTE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_SCHEME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_STATUS_CODE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.HTTP_TARGET;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_HOST;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_METHOD;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_ROUTE;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_SCHEME;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_STATUS_CODE;
+import static io.opentelemetry.semconv.SemanticAttributes.HTTP_TARGET;
 
 import io.opentelemetry.context.propagation.TextMapGetter;
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,7 +45,7 @@ import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteHolder;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpRouteSource;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 
 import java.time.Instant;
 import java.util.Enumeration;

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/communication/StreamRequestHandlerInstrumentation.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/communication/StreamRequestHandlerInstrumentation.java
@@ -20,7 +20,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.instrumentation.api.instrumenter.LocalRootSpan;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeInstrumentation;
 import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/AbstractInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/AbstractInstrumentationTest.java
@@ -28,7 +28,7 @@ import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -145,7 +145,7 @@ public abstract class AbstractInstrumentationTest {
     }
 
     protected void readMetrics() {
-        OpenTelemetryTestTools.getMetricReader().read();
+        OpenTelemetryTestTools.getMetricReader().collectAllMetrics();
     }
 
     protected MetricData getMetric(String name) {

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/JavaScriptBootstrapHandlerInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/JavaScriptBootstrapHandlerInstrumentationTest.java
@@ -7,7 +7,7 @@ import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
 import com.vaadin.flow.server.VaadinRequest;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/StreamRequestHandlerInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/StreamRequestHandlerInstrumentationTest.java
@@ -6,7 +6,7 @@ import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
 import com.vaadin.flow.server.VaadinRequest;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/UidlRequestHandlerInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/UidlRequestHandlerInstrumentationTest.java
@@ -7,7 +7,7 @@ import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
 import com.vaadin.flow.server.VaadinRequest;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/rpc/EventRpcHandlerInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/communication/rpc/EventRpcHandlerInstrumentationTest.java
@@ -15,7 +15,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/server/VaadinServletInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/server/VaadinServletInstrumentationTest.java
@@ -14,7 +14,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/OpenTelemetryTestTools.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/OpenTelemetryTestTools.java
@@ -81,7 +81,7 @@ public class OpenTelemetryTestTools {
 
         metricReader = new TestMetricReader();
         SdkMeterProvider meterProvider = SdkMeterProvider.builder()
-                .registerMetricReader(metricReader).build();
+                .registerMetricReader(metricReader.getMetricReader()).build();
 
         openTelemetry = OpenTelemetrySdk.builder()
                 .setTracerProvider(sdkTracerProviderSpy)

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/OpenTelemetryTestTools.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/OpenTelemetryTestTools.java
@@ -11,7 +11,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import io.opentelemetry.semconv.ResourceAttributes;
 import org.mockito.Mockito;
 
 public class OpenTelemetryTestTools {

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/TestMetricReader.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/TestMetricReader.java
@@ -1,70 +1,32 @@
 package com.vaadin.extension.instrumentation.util;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.metrics.InstrumentType;
-import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
-import io.opentelemetry.sdk.metrics.export.MetricReader;
-import io.opentelemetry.sdk.metrics.export.MetricProducer;
 import io.opentelemetry.sdk.metrics.data.MetricData;
-import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public class TestMetricReader implements MetricReader, MetricProducer {
-    private final List<MetricData> metricData = new ArrayList<>();
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-    public CompletableResultCode flush() {
-        // Implement flush logic if needed
-        return CompletableResultCode.ofSuccess();
+public class TestMetricReader {
+    private final InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+
+    public InMemoryMetricReader getMetricReader() {
+        return metricReader;
     }
 
-    @Override
-    public void register(CollectionRegistration collectionRegistration) {
-
-    }
-
-    @Override
-    public CompletableResultCode forceFlush() {
-        return null;
-    }
-
-    @Override
-    public CompletableResultCode shutdown() {
-        // Implement shutdown logic if needed
-        return CompletableResultCode.ofSuccess();
-    }
-
-    public Collection<MetricData> collectAllMetrics() {
-        // Return the collected metrics
-        return new ArrayList<>(metricData);
-    }
-
-    public void addMetric(MetricData metric) {
-        metricData.add(metric);
+    public void collectAllMetrics() {
+        // This method triggers metric collection
+        metricReader.collectAllMetrics();
     }
 
     public MetricData getMetric(String name) {
-        Optional<MetricData> metric = metricData.stream()
-            .filter(m -> m.getName().equals(name))
-            .findFirst();
+        final var metricData = metricReader.collectAllMetrics();
+        Optional<MetricData> metric =
+            metricData.stream().filter(m -> m.getName().equals(name)).findFirst();
 
         assertTrue(metric.isPresent(), "Metric does not exist: " + name);
+
         return metric.get();
-    }
-
-    @Override
-    public Collection<MetricData> produce(Resource resource) {
-        return List.of();
-    }
-
-    @Override
-    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
-        return null;
     }
 }

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/TestMetricReader.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/TestMetricReader.java
@@ -5,50 +5,66 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
-import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
-import io.opentelemetry.sdk.metrics.internal.export.MetricProducer;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.resources.Resource;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
-public class TestMetricReader implements MetricReader {
-    private MetricProducer metricProducer;
-    private Collection<MetricData> metricData = new ArrayList<>();
+public class TestMetricReader implements MetricReader, MetricProducer {
+    private final List<MetricData> metricData = new ArrayList<>();
+
+    public CompletableResultCode flush() {
+        // Implement flush logic if needed
+        return CompletableResultCode.ofSuccess();
+    }
 
     @Override
-    public void register(CollectionRegistration registration) {
-        metricProducer = MetricProducer.asMetricProducer(registration);
-    }
+    public void register(CollectionRegistration collectionRegistration) {
 
-    public void read() {
-        metricData = metricProducer.collectAllMetrics();
-    }
-
-    public MetricData getMetric(String name) {
-        Optional<MetricData> metric = metricData.stream()
-                .filter(m -> m.getName().equals(name)).findFirst();
-
-        assertTrue(metric.isPresent(), "Metric does not exist: " + name);
-
-        return metric.get();
     }
 
     @Override
     public CompletableResultCode forceFlush() {
-        return CompletableResultCode.ofSuccess();
+        return null;
     }
 
     @Override
     public CompletableResultCode shutdown() {
+        // Implement shutdown logic if needed
         return CompletableResultCode.ofSuccess();
     }
 
+    public Collection<MetricData> collectAllMetrics() {
+        // Return the collected metrics
+        return new ArrayList<>(metricData);
+    }
+
+    public void addMetric(MetricData metric) {
+        metricData.add(metric);
+    }
+
+    public MetricData getMetric(String name) {
+        Optional<MetricData> metric = metricData.stream()
+            .filter(m -> m.getName().equals(name))
+            .findFirst();
+
+        assertTrue(metric.isPresent(), "Metric does not exist: " + name);
+        return metric.get();
+    }
+
     @Override
-    public AggregationTemporality getAggregationTemporality(
-            InstrumentType instrumentType) {
-        return AggregationTemporality.CUMULATIVE;
+    public Collection<MetricData> produce(Resource resource) {
+        return List.of();
+    }
+
+    @Override
+    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+        return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         <vaadin.license.checker.version>1.12.12</vaadin.license.checker.version>
         <spring.boot.version>3.2.5</spring.boot.version>
 
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <servlet.api.version>6.0.0</servlet.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,13 @@
         <vaadin.license.checker.version>1.12.12</vaadin.license.checker.version>
         <spring.boot.version>3.2.5</spring.boot.version>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <servlet.api.version>6.0.0</servlet.api.version>
         <annotation.api.version>2.1.1</annotation.api.version>
-        <opentelemetry.version>1.23.0</opentelemetry.version>
+        <opentelemetry.version>1.31.0</opentelemetry.version>
         <jetty.version>11.0.13</jetty.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.2.0</mockito.version>


### PR DESCRIPTION
## Description

Updated Observability Kit to use:
- OpenTelemetry 1.31.0
- ByteBuddy 1.15.0

Fixes # (issue)
- As a result Observability Kit now works on a Java 21 project as well 👍

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
