### PR TITLE
feat: add span duration metrics and processor for observability

### DIFF
--- a/observability-kit-agent/src/main/java/com/vaadin/extension/Constants.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/Constants.java
@@ -15,6 +15,7 @@ package com.vaadin.extension;
  */
 public class Constants {
     public static final String CONFIG_TRACE_LEVEL = "otel.instrumentation.vaadin.trace-level";
+    public static final String CONFIG_SPAN_TO_METRICS_ENABLED = "otel.instrumentation.vaadin.span-to-metrics.enabled";
 
     // Vaadin attribute names
     public static final String SESSION_ID = "vaadin.session.id";

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/conf/Configuration.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/conf/Configuration.java
@@ -9,6 +9,7 @@ import io.opentelemetry.javaagent.bootstrap.internal.AgentInstrumentationConfig;
  */
 public class Configuration {
     public static final TraceLevel TRACE_LEVEL = determineTraceLevel();
+    public static final boolean SPAN_TO_METRICS_ENABLED = determineSpanToMetricsEnabled();
 
     private static TraceLevel determineTraceLevel() {
         String traceLevelString = AgentInstrumentationConfig.get().getString(
@@ -18,6 +19,11 @@ public class Configuration {
         } catch (IllegalArgumentException ignored) {
             return TraceLevel.DEFAULT;
         }
+    }
+
+    private static boolean determineSpanToMetricsEnabled() {
+        return AgentInstrumentationConfig.get().getBoolean(
+                Constants.CONFIG_SPAN_TO_METRICS_ENABLED, false);
     }
 
     /**
@@ -30,5 +36,15 @@ public class Configuration {
      */
     public static boolean isEnabled(TraceLevel traceLevel) {
         return TRACE_LEVEL.includes(traceLevel);
+    }
+
+    /**
+     * Checks whether span-to-metrics recording is enabled. When enabled,
+     * span duration data will be recorded as metrics.
+     *
+     * @return true if span-to-metrics is enabled, false if not
+     */
+    public static boolean isSpanToMetricsEnabled() {
+        return SPAN_TO_METRICS_ENABLED;
     }
 }

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
@@ -84,7 +84,15 @@ public class ConfigurationDefaults
 
     private SpanProcessor spanToMetricProcessor(SpanProcessor spanProcessor,
             ConfigProperties configProperties) {
-        return SpanProcessor.composite(spanProcessor, new SpanToMetricProcessor());
+        // Only add SpanToMetricProcessor if explicitly enabled
+        boolean spanToMetricsEnabled = configProperties.getBoolean(
+                Constants.CONFIG_SPAN_TO_METRICS_ENABLED, false);
+        
+        if (spanToMetricsEnabled) {
+            return SpanProcessor.composite(spanProcessor, new SpanToMetricProcessor());
+        } else {
+            return spanProcessor;
+        }
     }
 
     private Map<String, String> getDefaultProperties() {

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
@@ -82,7 +82,7 @@ public class ConfigurationDefaults
         return spanExporter;
     }
 
-    private SpanProcessor spanToMetricProcessor(SpanProcessor spanProcessor,
+    SpanProcessor spanToMetricProcessor(SpanProcessor spanProcessor,
             ConfigProperties configProperties) {
         // Only add SpanToMetricProcessor if explicitly enabled
         boolean spanToMetricsEnabled = configProperties.getBoolean(

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/conf/ConfigurationDefaults.java
@@ -12,12 +12,13 @@ package com.vaadin.extension.conf;
 import static java.util.Collections.emptyMap;
 
 import com.vaadin.extension.Constants;
-
+import com.vaadin.extension.metrics.SpanToMetricProcessor;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.instrumentation.api.internal.ConfigPropertiesUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 import java.io.File;
@@ -70,7 +71,8 @@ public class ConfigurationDefaults
     public void customize(AutoConfigurationCustomizer autoConfiguration) {
         autoConfiguration
                 .addSpanExporterCustomizer(this::setSpanExporter)
-                .addPropertiesSupplier(this::getDefaultProperties);
+                .addPropertiesSupplier(this::getDefaultProperties)
+                .addSpanProcessorCustomizer(this::spanToMetricProcessor);
     }
 
     private SpanExporter setSpanExporter(SpanExporter spanExporter,
@@ -78,6 +80,11 @@ public class ConfigurationDefaults
         ConfigurationDefaults.configProperties = configProperties;
         ConfigurationDefaults.spanExporter = spanExporter;
         return spanExporter;
+    }
+
+    private SpanProcessor spanToMetricProcessor(SpanProcessor spanProcessor,
+            ConfigProperties configProperties) {
+        return SpanProcessor.composite(spanProcessor, new SpanToMetricProcessor());
     }
 
     private Map<String, String> getDefaultProperties() {

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
@@ -18,6 +18,7 @@ import java.util.function.BiConsumer;
 import io.opentelemetry.sdk.trace.data.SpanData;
 
 import com.vaadin.extension.conf.ConfigurationDefaults;
+import com.vaadin.extension.metrics.Metrics;
 
 /**
  * This is a consumer callback that is injected into an ObservabilityHandler
@@ -61,6 +62,16 @@ public class ObjectMapExporter
             }
         }
 
+        exportSpans.forEach(span -> {
+            // if (span.getName().contains("documentLoad")) {
+                Long durationNanos = span.getEndEpochNanos() - span.getStartEpochNanos();
+                Long durationMs = durationNanos / 1000000;  
+                System.out.println("Span name: " + span.getName());
+                Metrics.recordSpanDuration(span.getName(), durationMs, span.getTraceId());
+            // }
+        });
+
         ConfigurationDefaults.spanExporter.export(exportSpans);
+        
     }
 }

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
@@ -63,11 +63,9 @@ public class ObjectMapExporter
         }
 
         exportSpans.forEach(span -> {
-            // if (span.getName().contains("documentLoad")) {
                 Long durationNanos = span.getEndEpochNanos() - span.getStartEpochNanos();
                 Long durationMs = durationNanos / 1000000;  
                 Metrics.recordSpanDuration(span.getName(), durationMs, span.getSpanContext());
-            // }
         });
 
         ConfigurationDefaults.spanExporter.export(exportSpans);

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
@@ -63,9 +63,8 @@ public class ObjectMapExporter
         }
 
         exportSpans.forEach(span -> {
-                Long durationNanos = span.getEndEpochNanos() - span.getStartEpochNanos();
-                Long durationMs = durationNanos / 1000000;  
-                Metrics.recordSpanDuration(span.getName(), durationMs, span.getSpanContext());
+                long durationNanos = span.getEndEpochNanos() - span.getStartEpochNanos();
+                Metrics.recordSpanDuration(span.getName(), durationNanos, span.getSpanContext());
         });
 
         ConfigurationDefaults.spanExporter.export(exportSpans);

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
@@ -66,8 +66,7 @@ public class ObjectMapExporter
             // if (span.getName().contains("documentLoad")) {
                 Long durationNanos = span.getEndEpochNanos() - span.getStartEpochNanos();
                 Long durationMs = durationNanos / 1000000;  
-                System.out.println("Span name: " + span.getName());
-                Metrics.recordSpanDuration(span.getName(), durationMs, span.getTraceId());
+                Metrics.recordSpanDuration(span.getName(), durationMs, span.getSpanContext());
             // }
         });
 

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/instrumentation/client/ObjectMapExporter.java
@@ -17,6 +17,7 @@ import java.util.function.BiConsumer;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
 
+import com.vaadin.extension.conf.Configuration;
 import com.vaadin.extension.conf.ConfigurationDefaults;
 import com.vaadin.extension.metrics.Metrics;
 
@@ -63,8 +64,10 @@ public class ObjectMapExporter
         }
 
         exportSpans.forEach(span -> {
+            if (Configuration.isSpanToMetricsEnabled()) {
                 long durationNanos = span.getEndEpochNanos() - span.getStartEpochNanos();
                 Metrics.recordSpanDuration(span.getName(), durationNanos, span.getSpanContext());
+            }
         });
 
         ConfigurationDefaults.spanExporter.export(exportSpans);

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
@@ -18,7 +18,6 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.context.Context;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -35,7 +34,6 @@ public class Metrics {
 
     private static LongHistogram sessionDurationMeasurement;
     private static LongHistogram spanDurationHistogram;
-    private static LongHistogram documentLoadHistogram;
     private static InstantProvider instantProvider = Instant::now;
 
     static void setInstantProvider(InstantProvider instantProvider) {
@@ -71,13 +69,6 @@ public class Metrics {
             spanDurationHistogram = meter
                     .histogramBuilder("vaadin.span.duration")
                     .setDescription("Duration of spans in milliseconds")
-                    .setUnit("ms")
-                    .ofLongs()
-                    .build();
-
-            documentLoadHistogram = meter
-                    .histogramBuilder("vaadin.document.load")
-                    .setDescription("Duration of document load in milliseconds")
                     .setUnit("ms")
                     .ofLongs()
                     .build();
@@ -131,16 +122,13 @@ public class Metrics {
         Instant get();
     }
 
-    public static void recordSpanDuration(String spanName, long durationMs, SpanContext spanContext) {
+    public static void recordSpanDuration(String spanName, long durationNanos, SpanContext spanContext) {
+        long durationMs = durationNanos / 1000000;
         Metrics.ensureMetricsRegistered();
         Attributes attributes = Attributes.of(
             AttributeKey.stringKey("span.name"), spanName
         );
         spanDurationHistogram.record(durationMs, attributes);
-
-        if (spanName.contains("documentLoad") || spanName.contains("navigate") || spanName.contains("Navigate")) {
-            documentLoadHistogram.record(durationMs, attributes);
-        }
     }
 
 

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/Metrics.java
@@ -35,7 +35,6 @@ public class Metrics {
 
     private static LongHistogram sessionDurationMeasurement;
     private static LongHistogram spanDurationHistogram;
-    private static LongHistogram documentLoadHistogram;
     private static InstantProvider instantProvider = Instant::now;
 
     static void setInstantProvider(InstantProvider instantProvider) {
@@ -71,13 +70,6 @@ public class Metrics {
             spanDurationHistogram = meter
                     .histogramBuilder("vaadin.span.duration")
                     .setDescription("Duration of spans in milliseconds")
-                    .setUnit("ms")
-                    .ofLongs()
-                    .build();
-            
-            documentLoadHistogram = meter
-                    .histogramBuilder("vaadin.document.load.duration")
-                    .setDescription("Duration of document loads in milliseconds")
                     .setUnit("ms")
                     .ofLongs()
                     .build();
@@ -132,6 +124,7 @@ public class Metrics {
     }
 
     public static void recordSpanDuration(String spanName, long durationMs, SpanContext spanContext) {
+        Metrics.ensureMetricsRegistered();
         Attributes attributes = Attributes.of(
             AttributeKey.stringKey("span.name"), spanName
         );
@@ -142,10 +135,6 @@ public class Metrics {
             contextWithSpan = Context.current().with(
                 io.opentelemetry.api.trace.Span.wrap(spanContext)
             );
-        }
-        
-        if (spanName.contains("documentLoad")) {
-            documentLoadHistogram.record(durationMs, attributes, contextWithSpan);
         }
         spanDurationHistogram.record(durationMs, attributes, contextWithSpan);
     }

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/SpanToMetricProcessor.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/SpanToMetricProcessor.java
@@ -1,0 +1,32 @@
+package com.vaadin.extension.metrics;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+
+public class SpanToMetricProcessor implements SpanProcessor {
+
+    @Override
+    public boolean isEndRequired() {
+        return true;
+    }
+
+    @Override
+    public boolean isStartRequired() {
+        return false;
+    }
+
+    @Override
+    public void onEnd(ReadableSpan span) {
+        Long latencyMs = span.getLatencyNanos() / 1000000;
+        Metrics.recordSpanDuration(span.getName(), latencyMs, span.getSpanContext().getTraceId());
+    }
+
+    @Override
+    public void onStart(Context arg0, ReadWriteSpan arg1) {
+      
+    }
+
+
+}

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/SpanToMetricProcessor.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/SpanToMetricProcessor.java
@@ -19,8 +19,8 @@ public class SpanToMetricProcessor implements SpanProcessor {
 
     @Override
     public void onEnd(ReadableSpan span) {
-        Long latencyMs = span.getLatencyNanos() / 1000000;
-        Metrics.recordSpanDuration(span.getName(), latencyMs, span.getSpanContext());
+        long latencyNanos = span.getLatencyNanos();
+        Metrics.recordSpanDuration(span.getName(), latencyNanos, span.getSpanContext());
     }
 
     @Override

--- a/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/SpanToMetricProcessor.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/metrics/SpanToMetricProcessor.java
@@ -20,7 +20,7 @@ public class SpanToMetricProcessor implements SpanProcessor {
     @Override
     public void onEnd(ReadableSpan span) {
         Long latencyMs = span.getLatencyNanos() / 1000000;
-        Metrics.recordSpanDuration(span.getName(), latencyMs, span.getSpanContext().getTraceId());
+        Metrics.recordSpanDuration(span.getName(), latencyMs, span.getSpanContext());
     }
 
     @Override

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/conf/ConfigurationDefaultsTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/conf/ConfigurationDefaultsTest.java
@@ -1,0 +1,64 @@
+package com.vaadin.extension.conf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.vaadin.extension.Constants;
+
+import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationDefaultsTest {
+
+    @Test
+    public void spanToMetricProcessor_whenEnabled_addsSpanToMetricProcessor() {
+        ConfigurationDefaults configDefaults = new ConfigurationDefaults();
+        ConfigProperties configProperties = mock(ConfigProperties.class);
+        SpanProcessor originalProcessor = mock(SpanProcessor.class);
+        
+        // Mock configuration to return true for span-to-metrics enabled
+        when(configProperties.getBoolean(Constants.CONFIG_SPAN_TO_METRICS_ENABLED, false))
+                .thenReturn(true);
+        
+        SpanProcessor result = configDefaults.spanToMetricProcessor(originalProcessor, configProperties);
+        
+        // Should return a composite processor (different from the original)
+        assertNotSame(originalProcessor, result, "Should return composite processor when enabled");
+    }
+
+    @Test
+    public void spanToMetricProcessor_whenDisabled_returnsOriginalProcessor() {
+        ConfigurationDefaults configDefaults = new ConfigurationDefaults();
+        ConfigProperties configProperties = mock(ConfigProperties.class);
+        SpanProcessor originalProcessor = mock(SpanProcessor.class);
+        
+        // Mock configuration to return false for span-to-metrics enabled (default)
+        when(configProperties.getBoolean(Constants.CONFIG_SPAN_TO_METRICS_ENABLED, false))
+                .thenReturn(false);
+        
+        SpanProcessor result = configDefaults.spanToMetricProcessor(originalProcessor, configProperties);
+        
+        // Should return the same original processor
+        assertSame(originalProcessor, result, "Should return original processor when disabled");
+    }
+
+    @Test
+    public void spanToMetricProcessor_whenNotConfigured_defaultsToDisabled() {
+        ConfigurationDefaults configDefaults = new ConfigurationDefaults();
+        ConfigProperties configProperties = mock(ConfigProperties.class);
+        SpanProcessor originalProcessor = mock(SpanProcessor.class);
+        
+        // Mock configuration to use default value (false) when not explicitly set
+        when(configProperties.getBoolean(Constants.CONFIG_SPAN_TO_METRICS_ENABLED, false))
+                .thenReturn(false); // This simulates the default case
+        
+        SpanProcessor result = configDefaults.spanToMetricProcessor(originalProcessor, configProperties);
+        
+        // Should return the same original processor (disabled by default)
+        assertSame(originalProcessor, result, "Should default to disabled when not configured");
+    }
+}

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/AbstractInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/AbstractInstrumentationTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractInstrumentationTest {
     private VaadinSession mockSession;
     private VaadinService mockService;
     private Scope sessionScope;
-    private MockedStatic<Configuration> ConfigurationMock;
+    protected MockedStatic<Configuration> ConfigurationMock;
     private TraceLevel configuredTraceLevel;
 
     public UI getMockUI() {

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/AbstractInstrumentationTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/AbstractInstrumentationTest.java
@@ -106,6 +106,8 @@ public abstract class AbstractInstrumentationTest {
                     TraceLevel level = invocation.getArgument(0);
                     return configuredTraceLevel.includes(level);
                 });
+        ConfigurationMock.when(() -> Configuration.isSpanToMetricsEnabled())
+                .thenReturn(true);
     }
 
     @AfterEach

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/metrics/MetricsTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/metrics/MetricsTest.java
@@ -1,12 +1,16 @@
 package com.vaadin.extension.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.vaadin.extension.conf.Configuration;
 import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
 import com.vaadin.extension.instrumentation.server.VaadinSessionInstrumentation;
+import com.vaadin.extension.metrics.SpanToMetricProcessor;
 import com.vaadin.flow.server.VaadinSession;
+
+import io.opentelemetry.sdk.trace.ReadableSpan;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -103,6 +107,29 @@ class MetricsTest extends AbstractInstrumentationTest {
         // Verify span name attribute is recorded
         assertTrue(metricValue.getAttributes().asMap().containsKey(io.opentelemetry.api.common.AttributeKey.stringKey("span.name")));
         assertEquals(spanName, metricValue.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("span.name")));
+    }
+
+    @Test
+    public void spanToMetricsConfigurationRespected() {
+        // Test that the configuration mock works as expected
+        
+        // Disable span-to-metrics
+        ConfigurationMock.when(() -> Configuration.isSpanToMetricsEnabled())
+                .thenReturn(false);
+        
+        assertFalse(Configuration.isSpanToMetricsEnabled(), 
+                "Configuration should reflect disabled state");
+        
+        // Enable span-to-metrics
+        ConfigurationMock.when(() -> Configuration.isSpanToMetricsEnabled())
+                .thenReturn(true);
+        
+        assertTrue(Configuration.isSpanToMetricsEnabled(), 
+                "Configuration should reflect enabled state");
+        
+        // Reset to enabled for other tests
+        ConfigurationMock.when(() -> Configuration.isSpanToMetricsEnabled())
+                .thenReturn(true);
     }
 
     @Test

--- a/observability-kit-agent/src/test/java/com/vaadin/extension/metrics/MetricsTest.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/metrics/MetricsTest.java
@@ -3,6 +3,7 @@ package com.vaadin.extension.metrics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.vaadin.extension.conf.Configuration;
 import com.vaadin.extension.instrumentation.AbstractInstrumentationTest;
 import com.vaadin.extension.instrumentation.server.VaadinSessionInstrumentation;
 import com.vaadin.flow.server.VaadinSession;


### PR DESCRIPTION
- Introduced SpanToMetricProcessor to record span durations.
- Enhanced Metrics class with span and document load duration histograms.
- Updated ConfigurationDefaults to include span processor customization.
- Modified ObjectMapExporter to log span durations using the new metrics.