### PR TITLE
refactor: use BaseLicenseCheckerServiceInitListener as super class to LicenseCheckerServiceInitListener

### DIFF
--- a/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/LicenseCheckerServiceInitListener.java
+++ b/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/LicenseCheckerServiceInitListener.java
@@ -12,14 +12,10 @@ package com.vaadin.hilla.observability;
 import java.io.IOException;
 import java.util.Properties;
 
-import com.vaadin.flow.internal.UsageStatistics;
-import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinServiceInitListener;
-import com.vaadin.pro.licensechecker.BuildType;
-import com.vaadin.pro.licensechecker.LicenseChecker;
+import com.vaadin.flow.server.startup.BaseLicenseCheckerServiceInitListener;
 
 public class LicenseCheckerServiceInitListener
-        implements VaadinServiceInitListener {
+        extends BaseLicenseCheckerServiceInitListener {
 
     static final String PROPERTIES_RESOURCE = "observability-kit.properties";
 
@@ -27,23 +23,16 @@ public class LicenseCheckerServiceInitListener
 
     static final String PRODUCT_NAME = "hilla-observability-kit";
 
-    @Override
-    public void serviceInit(ServiceInitEvent serviceInitEvent) {
-        final var service = serviceInitEvent.getSource();
+    static final String PRODUCT_VERSION;
+
+    static {
         final var properties = loadAllProperties(PROPERTIES_RESOURCE);
-        final var version = properties.getProperty(VERSION_PROPERTY);
-
-        UsageStatistics.markAsUsed(PRODUCT_NAME, version);
-
-        // Check the license at runtime if in development mode
-        if (!service.getDeploymentConfiguration().isProductionMode()) {
-            // Using a null BuildType to allow trial licensing builds
-            // The variable is defined to avoid method signature ambiguity
-            BuildType buildType = null;
-            LicenseChecker.checkLicense(PRODUCT_NAME, version, buildType);
-        }
+        PRODUCT_VERSION = properties.getProperty(VERSION_PROPERTY);
     }
 
+    public LicenseCheckerServiceInitListener() {
+        super(PRODUCT_NAME, PRODUCT_VERSION);
+    }
 
     static Properties loadAllProperties(String propertiesResource) {
         final var cl = LicenseCheckerServiceInitListener.class.getClassLoader();

--- a/observability-kit-starter/src/main/java/com/vaadin/observability/LicenseCheckerServiceInitListener.java
+++ b/observability-kit-starter/src/main/java/com/vaadin/observability/LicenseCheckerServiceInitListener.java
@@ -5,12 +5,12 @@ import java.util.Properties;
 
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.startup.BaseLicenseCheckerServiceInitListener;
 import com.vaadin.pro.licensechecker.BuildType;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 
 public class LicenseCheckerServiceInitListener
-        implements VaadinServiceInitListener {
+        extends BaseLicenseCheckerServiceInitListener {
 
     static final String PROPERTIES_RESOURCE = "observability-kit.properties";
 
@@ -18,23 +18,16 @@ public class LicenseCheckerServiceInitListener
 
     static final String PRODUCT_NAME = "vaadin-observability-kit";
 
-    @Override
-    public void serviceInit(ServiceInitEvent serviceInitEvent) {
-        final var service = serviceInitEvent.getSource();
+    static final String PRODUCT_VERSION;
+
+    static {
         final var properties = loadAllProperties(PROPERTIES_RESOURCE);
-        final var version = properties.getProperty(VERSION_PROPERTY);
-
-        UsageStatistics.markAsUsed(PRODUCT_NAME, version);
-
-        // Check the license at runtime if in development mode
-        if (!service.getDeploymentConfiguration().isProductionMode()) {
-            // Using a null BuildType to allow trial licensing builds
-            // The variable is defined to avoid method signature ambiguity
-            BuildType buildType = null;
-            LicenseChecker.checkLicense(PRODUCT_NAME, version, buildType);
-        }
+        PRODUCT_VERSION = properties.getProperty(VERSION_PROPERTY);
     }
 
+    public LicenseCheckerServiceInitListener() {
+        super(PRODUCT_NAME, PRODUCT_VERSION);
+    }
 
     static Properties loadAllProperties(String propertiesResource) {
         final var cl = LicenseCheckerServiceInitListener.class.getClassLoader();


### PR DESCRIPTION
## Description

- [x] Refactor the LicenseCheckerServiceInitListener to use the BaseLicenseCheckerServiceInitListener as its super class, no longer needing to implement the serviceInit(ServiceInitEvent) method.

I needed to add a static initialization block to initialize the `PRODUCT_VERSION` variable since its value is retrieved from a property file and it is needed to pass it to the super constructor.

Fixes #278 