### PR TITLE
Update OpenTelemetry agent version

### DIFF
--- a/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/OpenTelemetryTestTools.java
+++ b/observability-kit-agent/src/test/java/com/vaadin/extension/instrumentation/util/OpenTelemetryTestTools.java
@@ -13,7 +13,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.mockito.Mockito;
 
-import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
 
 public class OpenTelemetryTestTools {
 
@@ -46,9 +46,8 @@ public class OpenTelemetryTestTools {
         spanExporter = new TestExporter();
         spanBuilderCapture = new SpanBuilderCapture();
 
-        Resource resource = Resource.getDefault().merge(
-                Resource.create(Attributes.of(SERVICE_NAME,
-                        "test-service-name")));
+        Resource resource = Resource.getDefault().merge(Resource
+                .create(Attributes.of(SERVICE_NAME, "test-service-name")));
 
         SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <servlet.api.version>6.0.0</servlet.api.version>
         <annotation.api.version>2.1.1</annotation.api.version>
         <opentelemetry.version>1.44.1</opentelemetry.version>
-        <opentelemetry.javaagent.version>2.10.0</opentelemetry.javaagent.version>
+        <opentelemetry.javaagent.version>2.20.1</opentelemetry.javaagent.version>
         <jetty.version>11.0.26</jetty.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.20.0</mockito.version>


### PR DESCRIPTION
This updates the OpenTelemetry agent version to the latest (2.20.1).