### PR TITLE
fix: make sure ObservabilityEndpoint is detected by Hilla

### DIFF
--- a/observability-kit-demo-hilla/src/main/frontend/views/login-view.ts
+++ b/observability-kit-demo-hilla/src/main/frontend/views/login-view.ts
@@ -1,5 +1,5 @@
-import '@vaadin/button';
-import '@vaadin/login';
+import '@vaadin/button/vaadin-button.js';
+import '@vaadin/login/vaadin-login-form.js';
 import type { LoginFormLoginEvent } from '@vaadin/login/vaadin-login-form';
 import '@vaadin/text-field';
 import { html, type TemplateResult } from 'lit';

--- a/observability-kit-demo-hilla/src/main/java/com/example/application/hilla/SecurityConfiguration.java
+++ b/observability-kit-demo-hilla/src/main/java/com/example/application/hilla/SecurityConfiguration.java
@@ -59,7 +59,7 @@ public class SecurityConfiguration extends VaadinWebSecurity {
                         .matcher("/images/*.png"),
                 // Icons from the line-awesome addon
                 PathPatternRequestMatcher.withDefaults()
-                        .matcher("/line-awesome/**/*.svg"))
+                        .matcher("/line-awesome/**"))
                 .permitAll();
     }
 

--- a/observability-kit-starter-hilla/pom.xml
+++ b/observability-kit-starter-hilla/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>license-checker</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/ObservabilityKitConfiguration.java
+++ b/observability-kit-starter-hilla/src/main/java/com/vaadin/hilla/observability/ObservabilityKitConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2025 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ *
+ */
+
+package com.vaadin.hilla.observability;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+class ObservabilityKitConfiguration {
+
+    @Bean
+    ObservabilityEndpoint observabilityEndpoint() {
+        return new ObservabilityEndpoint();
+    }
+}

--- a/observability-kit-starter-hilla/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/observability-kit-starter-hilla/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.vaadin.hilla.observability.ObservabilityKitConfiguration


### PR DESCRIPTION
Adds an autoconfiguration class to expose ObservabilityEndpoint as bean so that Hilla discovery mechanism can automatically find it. Also fixes the Hilla demo