### PR TITLE
chore: upgrade opentelemetry.version and matching javaagent version

### DIFF
--- a/observability-kit-agent/src/main/java/com/vaadin/extension/ClasspathByteBuddyPlugin.java
+++ b/observability-kit-agent/src/main/java/com/vaadin/extension/ClasspathByteBuddyPlugin.java
@@ -9,7 +9,11 @@
  */
 package com.vaadin.extension;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.URLClassLoader;
 
 import io.opentelemetry.javaagent.tooling.muzzle.generation.MuzzleCodeGenerationPlugin;
@@ -20,7 +24,7 @@ import net.bytebuddy.dynamic.DynamicType.Builder;
 
 /**
  * Wrapper for OpenTelemetry {@link MuzzleCodeGenerationPlugin} to provide the
- * current {@link URLClassLoader} and instrument the instrumentation module.
+ * current classpath and instrument the instrumentation module.
  */
 public class ClasspathByteBuddyPlugin implements Plugin {
 
@@ -29,9 +33,15 @@ public class ClasspathByteBuddyPlugin implements Plugin {
     /**
      * Creates the plugin instance.
      */
-    public ClasspathByteBuddyPlugin() {
+    public ClasspathByteBuddyPlugin()
+            throws MalformedURLException, URISyntaxException {
         URLClassLoader cl = (URLClassLoader) getClass().getClassLoader();
-        delegate = new MuzzleCodeGenerationPlugin(cl);
+        URL[] urls = cl.getURLs();
+        File[] classpath = new File[urls.length];
+        for (int i = 0; i < urls.length; i++) {
+            classpath[i] = new File(urls[i].toURI());
+        }
+        delegate = new MuzzleCodeGenerationPlugin(classpath);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <servlet.api.version>6.0.0</servlet.api.version>
         <annotation.api.version>2.1.1</annotation.api.version>
         <opentelemetry.version>1.62.0</opentelemetry.version>
-        <opentelemetry.javaagent.version>2.26.1</opentelemetry.javaagent.version>
+        <opentelemetry.javaagent.version>2.28.0</opentelemetry.javaagent.version>
         <jetty.version>11.0.26</jetty.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.20.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <servlet.api.version>6.0.0</servlet.api.version>
         <annotation.api.version>2.1.1</annotation.api.version>
-        <opentelemetry.version>1.60.1</opentelemetry.version>
+        <opentelemetry.version>1.62.0</opentelemetry.version>
         <opentelemetry.javaagent.version>2.26.1</opentelemetry.javaagent.version>
         <jetty.version>11.0.26</jetty.version>
         <junit.version>5.9.2</junit.version>


### PR DESCRIPTION
resolve https://github.com/advisories/GHSA-rcgg-9c38-7xpx

The fix: `MuzzleCodeGenerationPlugin` in OTel javaagent 2.28.0 changed its constructor from `URLClassLoader` to `File[]`. Updated  `ClasspathByteBuddyPlugin.java:32-41` to convert the `URLClassLoader`'s URLs to a `File[]` before passing through.

