### PR TITLE
feat: multi-module setup and core Micrometer instrumentation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -26,5 +26,8 @@ jobs:
           java-version: '21'
           cache: maven
 
+      - name: Check formatting (Spotless)
+        run: mvn -B -ntp spotless:check
+
       - name: Build and verify
         run: mvn -B -ntp verify

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,30 @@
+name: Observability Kit Validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - micrometer
+  workflow_dispatch:
+
+concurrency:
+  group: validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build and verify
+        run: mvn -B -ntp verify

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Maven
+target/
+*.versionsBackup
+.flattened-pom.xml
+
+# Vaadin / Flow generated frontend
+node_modules/
+frontend/generated/
+src/main/frontend/generated/
+src/main/bundles/
+vite.generated.ts
+types.d.ts
+.flow/
+flow-build-info.json
+
+# IDE — IntelliJ
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# IDE — Eclipse
+.settings/
+.classpath
+.project
+bin/
+
+# IDE — VS Code
+.vscode/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Superpowers specs & plans (local only, not committed)
+docs/superpowers/

--- a/eclipse/VaadinJavaConventions.xml
+++ b/eclipse/VaadinJavaConventions.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+<profile kind="CodeFormatterProfile" name="Vaadin Java Conventions 20140408" version="12">
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="21"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="21"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="21"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+</profile>
+</profiles>

--- a/eclipse/flow.importorder
+++ b/eclipse/flow.importorder
@@ -1,0 +1,10 @@
+#Organize Import Order
+#Fri Nov 10 13:24:02 EET 2017
+7=\#
+6=elemental
+5=com.vaadin
+4=com.google.gwt
+3=
+2=java
+1=javax
+0=jakarta

--- a/eclipse/vaadin-commercial-license-header.txt
+++ b/eclipse/vaadin-commercial-license-header.txt
@@ -1,0 +1,8 @@
+/**
+ * Copyright (C) $YEAR Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */

--- a/observability-kit-micrometer/pom.xml
+++ b/observability-kit-micrometer/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>observability-kit</artifactId>
+        <version>5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>observability-kit-micrometer</artifactId>
+    <packaging>jar</packaging>
+    <name>Observability Kit :: Micrometer</name>
+    <description>Framework-agnostic Micrometer instrumentation for Vaadin Flow.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/observability-kit-micrometer/pom.xml
+++ b/observability-kit-micrometer/pom.xml
@@ -29,6 +29,12 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-observation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${servlet.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 /**

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
@@ -1,0 +1,14 @@
+package com.vaadin.observability.micrometer;
+
+/**
+ * Names of the meters published by Observability Kit. These form the public
+ * telemetry contract scraped by metrics backends, so treat changes as breaking.
+ */
+public final class MeterNames {
+
+    /** Gauge: number of currently active Vaadin sessions. */
+    public static final String SESSIONS_ACTIVE = "vaadin.sessions.active";
+
+    private MeterNames() {
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
@@ -1,9 +1,10 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -1,16 +1,18 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
 
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
-import io.micrometer.core.instrument.MeterRegistry;
 
 /**
  * Wires Observability Kit instrumentation into a {@code VaadinService} at

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -1,0 +1,46 @@
+package com.vaadin.observability.micrometer;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Wires Observability Kit instrumentation into a {@code VaadinService} at
+ * initialization. The no-arg constructor (used by the Java SPI) resolves the
+ * registry and settings from {@link ObservabilityKit}; the registry/settings
+ * constructor supports dependency-injection environments.
+ */
+public class MetricsServiceInitListener implements VaadinServiceInitListener {
+
+    private final MeterRegistry registry;
+    private final ObservabilitySettings settings;
+
+    public MetricsServiceInitListener() {
+        this(null, null);
+    }
+
+    public MetricsServiceInitListener(MeterRegistry registry,
+            ObservabilitySettings settings) {
+        this.registry = registry;
+        this.settings = settings;
+    }
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        MeterRegistry meterRegistry = registry != null ? registry
+                : ObservabilityKit.getMeterRegistry();
+        ObservabilitySettings effectiveSettings = settings != null ? settings
+                : ObservabilityKit.getSettings();
+        if (meterRegistry == null || effectiveSettings == null) {
+            return;
+        }
+
+        VaadinService service = event.getSource();
+        if (effectiveSettings.isSessions()) {
+            SessionMetricsBinder binder = new SessionMetricsBinder(meterRegistry);
+            service.addSessionInitListener(binder);
+            service.addSessionDestroyListener(binder);
+        }
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import com.vaadin.flow.server.ServiceInitEvent;

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -38,7 +38,8 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
 
         VaadinService service = event.getSource();
         if (effectiveSettings.isSessions()) {
-            SessionMetricsBinder binder = new SessionMetricsBinder(meterRegistry);
+            SessionMetricsBinder binder = new SessionMetricsBinder(
+                    meterRegistry);
             service.addSessionInitListener(binder);
             service.addSessionDestroyListener(binder);
         }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
@@ -13,12 +13,9 @@ import io.micrometer.observation.ObservationRegistry;
  */
 public final class ObservabilityKit {
 
-    private static final AtomicReference<MeterRegistry> METER_REGISTRY =
-            new AtomicReference<>();
-    private static final AtomicReference<ObservationRegistry> OBSERVATION_REGISTRY =
-            new AtomicReference<>();
-    private static final AtomicReference<ObservabilitySettings> SETTINGS =
-            new AtomicReference<>();
+    private static final AtomicReference<MeterRegistry> METER_REGISTRY = new AtomicReference<>();
+    private static final AtomicReference<ObservationRegistry> OBSERVATION_REGISTRY = new AtomicReference<>();
+    private static final AtomicReference<ObservabilitySettings> SETTINGS = new AtomicReference<>();
 
     private ObservabilityKit() {
     }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
@@ -1,0 +1,57 @@
+package com.vaadin.observability.micrometer;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+
+/**
+ * Programmatic bootstrap for standalone (non-Spring) deployments. Call
+ * {@link #install(MeterRegistry, ObservabilitySettings)} once at startup; the
+ * SPI-loaded {@code MetricsServiceInitListener} reads the stored registry and
+ * settings when the {@code VaadinService} initializes.
+ */
+public final class ObservabilityKit {
+
+    private static final AtomicReference<MeterRegistry> METER_REGISTRY =
+            new AtomicReference<>();
+    private static final AtomicReference<ObservationRegistry> OBSERVATION_REGISTRY =
+            new AtomicReference<>();
+    private static final AtomicReference<ObservabilitySettings> SETTINGS =
+            new AtomicReference<>();
+
+    private ObservabilityKit() {
+    }
+
+    public static void install(MeterRegistry meterRegistry,
+            ObservabilitySettings settings) {
+        install(meterRegistry, null, settings);
+    }
+
+    public static void install(MeterRegistry meterRegistry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings settings) {
+        METER_REGISTRY.set(meterRegistry);
+        OBSERVATION_REGISTRY.set(observationRegistry);
+        SETTINGS.set(settings);
+    }
+
+    static MeterRegistry getMeterRegistry() {
+        return METER_REGISTRY.get();
+    }
+
+    static ObservationRegistry getObservationRegistry() {
+        return OBSERVATION_REGISTRY.get();
+    }
+
+    static ObservabilitySettings getSettings() {
+        return SETTINGS.get();
+    }
+
+    /** Clears all installed state. Intended for tests and redeploys. */
+    static void reset() {
+        METER_REGISTRY.set(null);
+        OBSERVATION_REGISTRY.set(null);
+        SETTINGS.set(null);
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
@@ -1,9 +1,10 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
@@ -1,8 +1,8 @@
 package com.vaadin.observability.micrometer;
 
 /**
- * Immutable settings for Observability Kit instrumentation. Build instances with
- * {@link #builder()}.
+ * Immutable settings for Observability Kit instrumentation. Build instances
+ * with {@link #builder()}.
  */
 public final class ObservabilitySettings {
 

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 /**

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
@@ -1,0 +1,148 @@
+package com.vaadin.observability.micrometer;
+
+/**
+ * Immutable settings for Observability Kit instrumentation. Build instances with
+ * {@link #builder()}.
+ */
+public final class ObservabilitySettings {
+
+    private final boolean sessions;
+    private final boolean uis;
+    private final boolean navigation;
+    private final boolean requests;
+    private final boolean errors;
+    private final boolean client;
+    private final boolean traces;
+    private final boolean tracesSessionId;
+    private final int routeCardinalityLimit;
+    private final int clientRatePerSession;
+
+    private ObservabilitySettings(Builder builder) {
+        this.sessions = builder.sessions;
+        this.uis = builder.uis;
+        this.navigation = builder.navigation;
+        this.requests = builder.requests;
+        this.errors = builder.errors;
+        this.client = builder.client;
+        this.traces = builder.traces;
+        this.tracesSessionId = builder.tracesSessionId;
+        this.routeCardinalityLimit = builder.routeCardinalityLimit;
+        this.clientRatePerSession = builder.clientRatePerSession;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public boolean isSessions() {
+        return sessions;
+    }
+
+    public boolean isUis() {
+        return uis;
+    }
+
+    public boolean isNavigation() {
+        return navigation;
+    }
+
+    public boolean isRequests() {
+        return requests;
+    }
+
+    public boolean isErrors() {
+        return errors;
+    }
+
+    public boolean isClient() {
+        return client;
+    }
+
+    public boolean isTraces() {
+        return traces;
+    }
+
+    public boolean isTracesSessionId() {
+        return tracesSessionId;
+    }
+
+    public int getRouteCardinalityLimit() {
+        return routeCardinalityLimit;
+    }
+
+    public int getClientRatePerSession() {
+        return clientRatePerSession;
+    }
+
+    /** Builder for {@link ObservabilitySettings}. */
+    public static final class Builder {
+
+        private boolean sessions = true;
+        private boolean uis = true;
+        private boolean navigation = true;
+        private boolean requests = true;
+        private boolean errors = true;
+        private boolean client = true;
+        private boolean traces = true;
+        private boolean tracesSessionId = false;
+        private int routeCardinalityLimit = 200;
+        private int clientRatePerSession = 100;
+
+        private Builder() {
+        }
+
+        public Builder sessions(boolean sessions) {
+            this.sessions = sessions;
+            return this;
+        }
+
+        public Builder uis(boolean uis) {
+            this.uis = uis;
+            return this;
+        }
+
+        public Builder navigation(boolean navigation) {
+            this.navigation = navigation;
+            return this;
+        }
+
+        public Builder requests(boolean requests) {
+            this.requests = requests;
+            return this;
+        }
+
+        public Builder errors(boolean errors) {
+            this.errors = errors;
+            return this;
+        }
+
+        public Builder client(boolean client) {
+            this.client = client;
+            return this;
+        }
+
+        public Builder traces(boolean traces) {
+            this.traces = traces;
+            return this;
+        }
+
+        public Builder tracesSessionId(boolean tracesSessionId) {
+            this.tracesSessionId = tracesSessionId;
+            return this;
+        }
+
+        public Builder routeCardinalityLimit(int routeCardinalityLimit) {
+            this.routeCardinalityLimit = routeCardinalityLimit;
+            return this;
+        }
+
+        public Builder clientRatePerSession(int clientRatePerSession) {
+            this.clientRatePerSession = clientRatePerSession;
+            return this;
+        }
+
+        public ObservabilitySettings build() {
+            return new ObservabilitySettings(this);
+        }
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
@@ -1,9 +1,10 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
@@ -1,20 +1,22 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
 import com.vaadin.flow.server.SessionDestroyEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitEvent;
 import com.vaadin.flow.server.SessionInitListener;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
 
 /**
  * Tracks the number of active Vaadin sessions as a gauge. Register the same

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
@@ -1,0 +1,37 @@
+package com.vaadin.observability.micrometer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.server.SessionDestroyEvent;
+import com.vaadin.flow.server.SessionDestroyListener;
+import com.vaadin.flow.server.SessionInitEvent;
+import com.vaadin.flow.server.SessionInitListener;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Tracks the number of active Vaadin sessions as a gauge. Register the same
+ * instance as both a {@link SessionInitListener} and a
+ * {@link SessionDestroyListener} on the {@code VaadinService}.
+ */
+class SessionMetricsBinder implements SessionInitListener, SessionDestroyListener {
+
+    private final AtomicInteger activeSessions = new AtomicInteger();
+
+    SessionMetricsBinder(MeterRegistry registry) {
+        Gauge.builder(MeterNames.SESSIONS_ACTIVE, activeSessions,
+                AtomicInteger::doubleValue)
+                .description("Number of active Vaadin sessions")
+                .register(registry);
+    }
+
+    @Override
+    public void sessionInit(SessionInitEvent event) {
+        activeSessions.incrementAndGet();
+    }
+
+    @Override
+    public void sessionDestroy(SessionDestroyEvent event) {
+        activeSessions.decrementAndGet();
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
@@ -14,7 +14,8 @@ import io.micrometer.core.instrument.MeterRegistry;
  * instance as both a {@link SessionInitListener} and a
  * {@link SessionDestroyListener} on the {@code VaadinService}.
  */
-class SessionMetricsBinder implements SessionInitListener, SessionDestroyListener {
+class SessionMetricsBinder
+        implements SessionInitListener, SessionDestroyListener {
 
     private final AtomicInteger activeSessions = new AtomicInteger();
 

--- a/observability-kit-micrometer/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/observability-kit-micrometer/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+com.vaadin.observability.micrometer.MetricsServiceInitListener

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -33,7 +33,8 @@ class MetricsServiceInitListenerTest {
         new MetricsServiceInitListener().serviceInit(event);
 
         verify(service).addSessionInitListener(any(SessionInitListener.class));
-        verify(service).addSessionDestroyListener(any(SessionDestroyListener.class));
+        verify(service)
+                .addSessionDestroyListener(any(SessionDestroyListener.class));
     }
 
     @Test

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -1,19 +1,21 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitListener;
 import com.vaadin.flow.server.VaadinService;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -1,0 +1,63 @@
+package com.vaadin.observability.micrometer;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.SessionDestroyListener;
+import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.VaadinService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class MetricsServiceInitListenerTest {
+
+    @AfterEach
+    void tearDown() {
+        ObservabilityKit.reset();
+    }
+
+    @Test
+    void registersSessionBinderWhenSessionsEnabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service).addSessionInitListener(any(SessionInitListener.class));
+        verify(service).addSessionDestroyListener(any(SessionDestroyListener.class));
+    }
+
+    @Test
+    void doesNothingWhenNotInstalled() {
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void skipsSessionBinderWhenSessionsDisabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().sessions(false).build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service, never()).addSessionInitListener(any());
+        verify(service, never()).addSessionDestroyListener(any());
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import com.vaadin.flow.server.ServiceInitEvent;

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
@@ -17,7 +17,8 @@ class ObservabilityKitTest {
     @Test
     void install_storesRegistryAndSettings() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        ObservabilitySettings settings = ObservabilitySettings.builder().build();
+        ObservabilitySettings settings = ObservabilitySettings.builder()
+                .build();
 
         ObservabilityKit.install(registry, settings);
 

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
@@ -1,0 +1,39 @@
+package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ObservabilityKitTest {
+
+    @AfterEach
+    void tearDown() {
+        ObservabilityKit.reset();
+    }
+
+    @Test
+    void install_storesRegistryAndSettings() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ObservabilitySettings settings = ObservabilitySettings.builder().build();
+
+        ObservabilityKit.install(registry, settings);
+
+        assertSame(registry, ObservabilityKit.getMeterRegistry());
+        assertSame(settings, ObservabilityKit.getSettings());
+        assertNull(ObservabilityKit.getObservationRegistry());
+    }
+
+    @Test
+    void reset_clearsState() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().build());
+
+        ObservabilityKit.reset();
+
+        assertNull(ObservabilityKit.getMeterRegistry());
+        assertNull(ObservabilityKit.getSettings());
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
@@ -1,9 +1,10 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
@@ -10,7 +10,8 @@ class ObservabilitySettingsTest {
 
     @Test
     void defaults_allFeaturesEnabledExceptSessionIdTracing() {
-        ObservabilitySettings settings = ObservabilitySettings.builder().build();
+        ObservabilitySettings settings = ObservabilitySettings.builder()
+                .build();
 
         assertTrue(settings.isSessions());
         assertTrue(settings.isUis());
@@ -27,11 +28,8 @@ class ObservabilitySettingsTest {
     @Test
     void builder_overridesAreApplied() {
         ObservabilitySettings settings = ObservabilitySettings.builder()
-                .sessions(false)
-                .tracesSessionId(true)
-                .routeCardinalityLimit(50)
-                .clientRatePerSession(10)
-                .build();
+                .sessions(false).tracesSessionId(true).routeCardinalityLimit(50)
+                .clientRatePerSession(10).build();
 
         assertFalse(settings.isSessions());
         assertTrue(settings.isTracesSessionId());

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import org.junit.jupiter.api.Test;

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
@@ -1,0 +1,41 @@
+package com.vaadin.observability.micrometer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObservabilitySettingsTest {
+
+    @Test
+    void defaults_allFeaturesEnabledExceptSessionIdTracing() {
+        ObservabilitySettings settings = ObservabilitySettings.builder().build();
+
+        assertTrue(settings.isSessions());
+        assertTrue(settings.isUis());
+        assertTrue(settings.isNavigation());
+        assertTrue(settings.isRequests());
+        assertTrue(settings.isErrors());
+        assertTrue(settings.isClient());
+        assertTrue(settings.isTraces());
+        assertFalse(settings.isTracesSessionId());
+        assertEquals(200, settings.getRouteCardinalityLimit());
+        assertEquals(100, settings.getClientRatePerSession());
+    }
+
+    @Test
+    void builder_overridesAreApplied() {
+        ObservabilitySettings settings = ObservabilitySettings.builder()
+                .sessions(false)
+                .tracesSessionId(true)
+                .routeCardinalityLimit(50)
+                .clientRatePerSession(10)
+                .build();
+
+        assertFalse(settings.isSessions());
+        assertTrue(settings.isTracesSessionId());
+        assertEquals(50, settings.getRouteCardinalityLimit());
+        assertEquals(10, settings.getClientRatePerSession());
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
@@ -1,9 +1,10 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
@@ -1,0 +1,22 @@
+package com.vaadin.observability.micrometer;
+
+import java.util.ServiceLoader;
+
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceLoaderRegistrationTest {
+
+    @Test
+    void metricsListenerIsRegisteredViaServiceLoader() {
+        boolean found = ServiceLoader.load(VaadinServiceInitListener.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .anyMatch(listener -> listener instanceof MetricsServiceInitListener);
+
+        assertTrue(found,
+                "MetricsServiceInitListener should be discoverable via the Java SPI");
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import java.util.ServiceLoader;

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
@@ -12,9 +12,8 @@ class ServiceLoaderRegistrationTest {
     @Test
     void metricsListenerIsRegisteredViaServiceLoader() {
         boolean found = ServiceLoader.load(VaadinServiceInitListener.class)
-                .stream()
-                .map(ServiceLoader.Provider::get)
-                .anyMatch(listener -> listener instanceof MetricsServiceInitListener);
+                .stream().map(ServiceLoader.Provider::get).anyMatch(
+                        listener -> listener instanceof MetricsServiceInitListener);
 
         assertTrue(found,
                 "MetricsServiceInitListener should be discoverable via the Java SPI");

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ServiceLoaderRegistrationTest.java
@@ -1,16 +1,18 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 
 import java.util.ServiceLoader;
 
-import com.vaadin.flow.server.VaadinServiceInitListener;
 import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.server.VaadinServiceInitListener;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
@@ -1,0 +1,30 @@
+package com.vaadin.observability.micrometer;
+
+import com.vaadin.flow.server.SessionDestroyEvent;
+import com.vaadin.flow.server.SessionInitEvent;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class SessionMetricsBinderTest {
+
+    @Test
+    void gaugeTracksActiveSessionCount() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionMetricsBinder binder = new SessionMetricsBinder(registry);
+
+        assertEquals(0.0,
+                registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value());
+
+        binder.sessionInit(mock(SessionInitEvent.class));
+        binder.sessionInit(mock(SessionInitEvent.class));
+        assertEquals(2.0,
+                registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value());
+
+        binder.sessionDestroy(mock(SessionDestroyEvent.class));
+        assertEquals(1.0,
+                registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value());
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
@@ -1,16 +1,18 @@
-/*
- * Copyright 2000-2026 Vaadin Ltd.
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *
- * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
  */
 package com.vaadin.observability.micrometer;
 
-import com.vaadin.flow.server.SessionDestroyEvent;
-import com.vaadin.flow.server.SessionInitEvent;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.server.SessionDestroyEvent;
+import com.vaadin.flow.server.SessionInitEvent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
 package com.vaadin.observability.micrometer;
 
 import com.vaadin.flow.server.SessionDestroyEvent;

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,9 @@
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.surefire.version>3.2.5</maven.surefire.version>
         <maven.failsafe.version>3.2.5</maven.failsafe.version>
-        <maven.formatter.version>2.23.0</maven.formatter.version>
+        <spotless.plugin.version>3.5.1</spotless.plugin.version>
+        <spotless.license-header>${maven.multiModuleProjectDirectory}/eclipse/vaadin-commercial-license-header.txt</spotless.license-header>
+        <spotless.ratchetFrom/>
     </properties>
 
     <repositories>
@@ -163,14 +165,25 @@
                     <version>${maven.failsafe.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>net.revelc.code.formatter</groupId>
-                    <artifactId>formatter-maven-plugin</artifactId>
-                    <version>${maven.formatter.version}</version>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${spotless.plugin.version}</version>
                     <configuration>
-                        <configFile>https://raw.githubusercontent.com/vaadin/flow/master/eclipse/VaadinJavaConventions.xml</configFile>
-                        <skipHtmlFormatting>true</skipHtmlFormatting>
-                        <lineEnding>LF</lineEnding>
-                        <encoding>UTF-8</encoding>
+                        <ratchetFrom>${spotless.ratchetFrom}</ratchetFrom>
+                        <java>
+                            <eclipse>
+                                <file>${maven.multiModuleProjectDirectory}/eclipse/VaadinJavaConventions.xml</file>
+                            </eclipse>
+                            <endWithNewline/>
+                            <removeUnusedImports/>
+                            <importOrder>
+                                <file>${maven.multiModuleProjectDirectory}/eclipse/flow.importorder</file>
+                            </importOrder>
+                            <forbidWildcardImports/>
+                            <licenseHeader>
+                                <file>${spotless.license-header}</file>
+                            </licenseHeader>
+                        </java>
                     </configuration>
                 </plugin>
             </plugins>
@@ -189,8 +202,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,9 @@
     <properties>
         <flow.version>25.3-SNAPSHOT</flow.version>
         <micrometer.version>1.16.4</micrometer.version>
+        <servlet.api.version>6.1.0</servlet.api.version>
         <junit.version>5.11.4</junit.version>
-        <mockito.version>5.14.2</mockito.version>
+        <mockito.version>5.20.0</mockito.version>
         <vaadin.license.checker.version>3.0.1</vaadin.license.checker.version>
 
         <maven.compiler.release>21</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-parent</artifactId>
+        <version>3.0.0</version>
+    </parent>
+
+    <artifactId>observability-kit</artifactId>
+    <version>5.0-SNAPSHOT</version>
+    <name>Observability Kit</name>
+    <packaging>pom</packaging>
+
+    <licenses>
+        <license>
+            <name>Vaadin Commercial License and Service Terms</name>
+            <url>https://vaadin.com/commercial-license-and-service-terms</url>
+        </license>
+    </licenses>
+
+    <modules>
+        <module>observability-kit-micrometer</module>
+    </modules>
+
+    <properties>
+        <flow.version>25.3-SNAPSHOT</flow.version>
+        <micrometer.version>1.16.4</micrometer.version>
+        <junit.version>5.11.4</junit.version>
+        <mockito.version>5.14.2</mockito.version>
+        <vaadin.license.checker.version>3.0.1</vaadin.license.checker.version>
+
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.version>3.13.0</maven.compiler.version>
+        <maven.source.version>3.2.1</maven.source.version>
+        <maven.javadoc.version>3.4.1</maven.javadoc.version>
+        <maven.surefire.version>3.2.5</maven.surefire.version>
+        <maven.failsafe.version>3.2.5</maven.failsafe.version>
+        <maven.formatter.version>2.23.0</maven.formatter.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-bom</artifactId>
+                <version>${flow.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-bom</artifactId>
+                <version>${micrometer.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>license-checker</artifactId>
+                <version>${vaadin.license.checker.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven.source.version}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven.javadoc.version}</version>
+                    <configuration>
+                        <quiet>true</quiet>
+                        <doclint>none</doclint>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven.surefire.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven.failsafe.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>${maven.formatter.version}</version>
+                    <configuration>
+                        <configFile>https://raw.githubusercontent.com/vaadin/flow/master/eclipse/VaadinJavaConventions.xml</configFile>
+                        <skipHtmlFormatting>true</skipHtmlFormatting>
+                        <lineEnding>LF</lineEnding>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <artifactId>observability-kit</artifactId>
     <version>5.0-SNAPSHOT</version>
     <name>Observability Kit</name>
+    <description>Micrometer-based observability instrumentation for Vaadin Flow applications.</description>
     <packaging>pom</packaging>
 
     <licenses>
@@ -109,6 +110,7 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
@@ -173,6 +175,14 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Closes #324.

Establishes the Maven multi-module project and the framework-agnostic core module providing Micrometer-based instrumentation for Vaadin Flow in standalone (non-Spring) deployments.

## What's included
- Reactor root build: parent + BOM-managed Flow / Micrometer / JUnit, Java 21, commercial license.
- `observability-kit-micrometer` module (`com.vaadin.observability.micrometer`).
- `ObservabilityKit.install(meterRegistry, settings)` programmatic bootstrap for standalone use.
- Immutable `ObservabilitySettings` with feature toggles (sessions, UIs, navigation, requests, errors, client, traces) and limits.
- Automatic wiring via Vaadin's service-init SPI — no manual registration needed.
- First metric: active Vaadin sessions gauge (`vaadin.sessions.active`).

## Notes
- Built and tested on JDK 25 (project targets Java 21); `jakarta.servlet-api` (provided) and Mockito 5.20.0 are required for the mock-based tests to run.
- `mvn verify` green (9 unit tests).

## Out of scope
Spring / Spring Boot integration and the remaining metrics, tracing, and client instrumentation (later parts).