### PR TITLE
Part 2: Complete core metrics, tracing, and client instrumentation

### DIFF
--- a/observability-kit-micrometer/pom.xml
+++ b/observability-kit-micrometer/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>micrometer-observation</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>context-propagation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <version>${servlet.api.version}</version>

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MeterNames.java
@@ -17,6 +17,52 @@ public final class MeterNames {
     /** Gauge: number of currently active Vaadin sessions. */
     public static final String SESSIONS_ACTIVE = "vaadin.sessions.active";
 
+    public static final String SESSIONS_CREATED = "vaadin.sessions.created";
+    public static final String SESSIONS_DURATION = "vaadin.sessions.duration";
+
+    public static final String SESSION_LOCK_WAIT = "vaadin.session.lock.wait";
+    public static final String SESSION_LOCK_HOLD = "vaadin.session.lock.hold";
+
+    public static final String UI_ACTIVE = "vaadin.ui.active";
+    public static final String UI_CREATED = "vaadin.ui.created";
+
+    public static final String NAVIGATION = "vaadin.navigation";
+
+    public static final String REQUEST_DURATION = "vaadin.request.duration";
+
+    public static final String ERRORS = "vaadin.errors";
+
+    public static final String CLIENT_BOOTSTRAP_DURATION = "vaadin.client.bootstrap.duration";
+    public static final String CLIENT_NAVIGATION_DURATION = "vaadin.client.navigation.duration";
+    public static final String CLIENT_RPC_DURATION = "vaadin.client.rpc.duration";
+    public static final String CLIENT_WEB_VITALS_LCP = "vaadin.client.web_vitals.lcp";
+    public static final String CLIENT_WEB_VITALS_FCP = "vaadin.client.web_vitals.fcp";
+    public static final String CLIENT_ERRORS = "vaadin.client.errors";
+    public static final String CLIENT_DROPPED = "vaadin.client.dropped";
+    public static final String CLIENT_THROTTLED = "vaadin.client.throttled";
+
+    public static final String TAG_ROUTE = "route";
+    public static final String TAG_OUTCOME = "outcome";
+    public static final String TAG_EXCEPTION = "exception";
+    public static final String TAG_TRIGGER = "trigger";
+    public static final String TAG_KIND = "kind";
+    public static final String TAG_CONTEXT = "context";
+
+    public static final String OUTCOME_SUCCESS = "success";
+    public static final String OUTCOME_ERROR = "error";
+
+    public static final String CONTEXT_REQUEST = "request";
+    public static final String CONTEXT_ACCESS = "access";
+
+    public static final String ROUTE_OTHER = "_other";
+    public static final String ROUTE_UNKNOWN = "_unknown";
+
+    /** Timer: server-side RPC invocation duration. */
+    public static final String RPC_DURATION = "vaadin.rpc.duration";
+
+    /** Tag key: RPC invocation type. */
+    public static final String TAG_TYPE = "type";
+
     private MeterNames() {
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -171,7 +171,8 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
                     new SessionLockMetricsBinder(registry));
         }
 
-        if (settings.isUis() || settings.isNavigation()) {
+        if (settings.isUis() || settings.isNavigation()
+                || settings.isClient()) {
             service.addUIInitListener(new UiMetricsBinder(registry,
                     observationRegistry, settings));
         }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -8,33 +8,115 @@
  */
 package com.vaadin.observability.micrometer;
 
+import java.util.Objects;
+
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.observability.micrometer.trace.TracingExecutor;
 
 /**
  * Wires Observability Kit instrumentation into a {@code VaadinService} at
- * initialization. The no-arg constructor (used by the Java SPI) resolves the
- * registry and settings from {@link ObservabilityKit}; the registry/settings
- * constructor supports dependency-injection environments.
+ * initialization.
+ * <p>
+ * Three construction paths:
+ * <ul>
+ * <li>Spring/Boot — instantiated as a bean with explicit {@code meterRegistry},
+ * {@code observationRegistry} (optional), and {@code settings} arguments.</li>
+ * <li>Spring/Boot without observation registry — use the two-arg
+ * constructor.</li>
+ * <li>Standalone — the no-arg constructor is invoked by the Java
+ * {@link java.util.ServiceLoader}; the registry and configuration are looked up
+ * from {@link ObservabilityKit} at {@code serviceInit} time. If
+ * {@link ObservabilityKit#install} was never called, the listener silently
+ * no-ops.</li>
+ * </ul>
+ * <p>
+ * When an {@link ObservationRegistry} is available and
+ * {@link ObservabilitySettings#isTraces()} is on, the listener also wraps the
+ * service's executor with a {@link TracingExecutor} so trace context flows
+ * across {@code UI.access(...)} boundaries.
  */
 public class MetricsServiceInitListener implements VaadinServiceInitListener {
 
-    private final MeterRegistry registry;
+    private final MeterRegistry meterRegistry;
+    private final ObservationRegistry observationRegistry;
     private final ObservabilitySettings settings;
 
+    /**
+     * Constructor used by {@link java.util.ServiceLoader}. Resolves the
+     * registry, observation registry, and settings lazily from
+     * {@link ObservabilityKit}.
+     */
     public MetricsServiceInitListener() {
-        this(null, null);
+        this.meterRegistry = null;
+        this.observationRegistry = null;
+        this.settings = null;
     }
 
-    public MetricsServiceInitListener(MeterRegistry registry,
+    /**
+     * Constructor used by DI containers that don't provide an
+     * {@link ObservationRegistry}.
+     *
+     * @param meterRegistry
+     *            Micrometer meter registry, not {@code null}
+     * @param settings
+     *            instrumentation settings, not {@code null}
+     */
+    public MetricsServiceInitListener(MeterRegistry meterRegistry,
             ObservabilitySettings settings) {
-        this.registry = registry;
-        this.settings = settings;
+        this(meterRegistry, null, settings);
+    }
+
+    /**
+     * Constructor used by DI containers.
+     *
+     * @param meterRegistry
+     *            Micrometer meter registry, not {@code null}
+     * @param observationRegistry
+     *            Micrometer observation registry, may be {@code null} to
+     *            disable Observation-based instrumentation
+     * @param settings
+     *            instrumentation settings, not {@code null}
+     */
+    public MetricsServiceInitListener(MeterRegistry meterRegistry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings settings) {
+        this.meterRegistry = Objects.requireNonNull(meterRegistry,
+                "meterRegistry");
+        this.observationRegistry = observationRegistry;
+        this.settings = Objects.requireNonNull(settings, "settings");
+        if (observationRegistry != null && settings.isTraces()) {
+            installDefaultObservationHandlers(observationRegistry,
+                    meterRegistry);
+        }
+    }
+
+    /**
+     * Registers default {@link io.micrometer.observation.ObservationHandler}s
+     * that make Observations produce
+     * {@link io.micrometer.core.instrument.Timer}s.
+     * <p>
+     * The default implementation installs
+     * {@link DefaultMeterObservationHandler}. Spring Boot deployments override
+     * this method to no-op because the Boot Actuator's
+     * {@code ObservationAutoConfiguration} already registers the same handler.
+     *
+     * @param observationRegistry
+     *            the registry to configure
+     * @param meterRegistry
+     *            the meter registry to attach timers to
+     */
+    protected void installDefaultObservationHandlers(
+            ObservationRegistry observationRegistry,
+            MeterRegistry meterRegistry) {
+        observationRegistry.observationConfig().observationHandler(
+                new DefaultMeterObservationHandler(meterRegistry));
     }
 
     /**
@@ -63,35 +145,46 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
 
     @Override
     public void serviceInit(ServiceInitEvent event) {
-        MeterRegistry meterRegistry = registry != null ? registry
+        MeterRegistry r = meterRegistry != null ? meterRegistry
                 : ObservabilityKit.getMeterRegistry();
-        ObservabilitySettings effectiveSettings = settings != null ? settings
+        ObservabilitySettings s = settings != null ? settings
                 : ObservabilityKit.getSettings();
-        if (meterRegistry == null || effectiveSettings == null) {
+        if (r == null || s == null) {
             return;
         }
-        ObservationRegistry observationRegistry = ObservabilityKit
-                .getObservationRegistry();
+        ObservationRegistry or = observationRegistry != null
+                ? observationRegistry
+                : ObservabilityKit.getObservationRegistry();
+        bind(event, r, or, s);
+    }
 
+    void bind(ServiceInitEvent event, MeterRegistry registry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings settings) {
         VaadinService service = event.getSource();
-        if (effectiveSettings.isSessions()) {
-            SessionMetricsBinder binder = new SessionMetricsBinder(
-                    meterRegistry);
+
+        if (settings.isSessions()) {
+            SessionMetricsBinder binder = new SessionMetricsBinder(registry);
             service.addSessionInitListener(binder);
             service.addSessionDestroyListener(binder);
             service.addSessionLockListener(
-                    new SessionLockMetricsBinder(meterRegistry));
+                    new SessionLockMetricsBinder(registry));
         }
 
-        if (effectiveSettings.isUis() || effectiveSettings.isNavigation()) {
-            service.addUIInitListener(new UiMetricsBinder(meterRegistry,
-                    observationRegistry, effectiveSettings));
+        if (settings.isUis() || settings.isNavigation()) {
+            service.addUIInitListener(new UiMetricsBinder(registry,
+                    observationRegistry, settings));
         }
 
-        if (effectiveSettings.isRequests() || effectiveSettings.isErrors()) {
+        if (settings.isRequests() || settings.isErrors()) {
             event.addVaadinRequestInterceptor(
-                    new RequestMetricsBinder(meterRegistry, observationRegistry,
-                            effectiveSettings, this::enrichHttpObservation));
+                    new RequestMetricsBinder(registry, observationRegistry,
+                            settings, this::enrichHttpObservation));
+        }
+
+        if (settings.isTraces() && observationRegistry != null) {
+            event.getExecutor().ifPresent(exec -> event.setExecutor(
+                    new TracingExecutor(exec, observationRegistry)));
         }
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -182,6 +182,11 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
                             settings, this::enrichHttpObservation));
         }
 
+        if (settings.isRequests()) {
+            service.addRpcInvocationListener(new RpcMetricsBinder(registry,
+                    observationRegistry, settings));
+        }
+
         if (settings.isTraces() && observationRegistry != null) {
             event.getExecutor().ifPresent(exec -> event.setExecutor(
                     new TracingExecutor(exec, observationRegistry)));

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 
 import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
@@ -36,6 +37,30 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
         this.settings = settings;
     }
 
+    /**
+     * Hook for DI integrations to enrich the framework-level HTTP observation
+     * (e.g. Spring's {@code ServerHttpObservationFilter} span) with
+     * Vaadin-specific information so the parent HTTP span renders informatively
+     * in the trace UI. Called from {@link RequestMetricsBinder} after the
+     * Vaadin request type has been determined and before the
+     * {@code vaadin.request.<type>} child observation is started.
+     * <p>
+     * Default implementation no-ops, keeping the framework-agnostic core free
+     * of Spring imports. The Spring/Boot integration modules override this to
+     * call into their respective HTTP-observation APIs.
+     *
+     * @param request
+     *            the current Vaadin request
+     * @param requestType
+     *            the classified request type (e.g. {@code uidl},
+     *            {@code heartbeat}, {@code push}, {@code static},
+     *            {@code other})
+     */
+    protected void enrichHttpObservation(VaadinRequest request,
+            String requestType) {
+        // no-op by default
+    }
+
     @Override
     public void serviceInit(ServiceInitEvent event) {
         MeterRegistry meterRegistry = registry != null ? registry
@@ -45,6 +70,8 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
         if (meterRegistry == null || effectiveSettings == null) {
             return;
         }
+        ObservationRegistry observationRegistry = ObservabilityKit
+                .getObservationRegistry();
 
         VaadinService service = event.getSource();
         if (effectiveSettings.isSessions()) {
@@ -57,10 +84,14 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
         }
 
         if (effectiveSettings.isUis() || effectiveSettings.isNavigation()) {
-            ObservationRegistry observationRegistry = ObservabilityKit
-                    .getObservationRegistry();
             service.addUIInitListener(new UiMetricsBinder(meterRegistry,
                     observationRegistry, effectiveSettings));
+        }
+
+        if (effectiveSettings.isRequests() || effectiveSettings.isErrors()) {
+            event.addVaadinRequestInterceptor(
+                    new RequestMetricsBinder(meterRegistry, observationRegistry,
+                            effectiveSettings, this::enrichHttpObservation));
         }
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -9,6 +9,7 @@
 package com.vaadin.observability.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
@@ -53,6 +54,13 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
             service.addSessionDestroyListener(binder);
             service.addSessionLockListener(
                     new SessionLockMetricsBinder(meterRegistry));
+        }
+
+        if (effectiveSettings.isUis() || effectiveSettings.isNavigation()) {
+            ObservationRegistry observationRegistry = ObservabilityKit
+                    .getObservationRegistry();
+            service.addUIInitListener(new UiMetricsBinder(meterRegistry,
+                    observationRegistry, effectiveSettings));
         }
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/MetricsServiceInitListener.java
@@ -51,6 +51,8 @@ public class MetricsServiceInitListener implements VaadinServiceInitListener {
                     meterRegistry);
             service.addSessionInitListener(binder);
             service.addSessionDestroyListener(binder);
+            service.addSessionLockListener(
+                    new SessionLockMetricsBinder(meterRegistry));
         }
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/NavigationMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/NavigationMetricsBinder.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationListener;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.observability.micrometer.trace.ObservationNames;
+
+/**
+ * Times each navigation from {@code beforeEnter} to {@code afterNavigation}.
+ * <p>
+ * When an {@link ObservationRegistry} is supplied and
+ * {@link ObservabilitySettings#isTraces()} is on, the navigation is observed
+ * (producing both a span and, through a registered
+ * {@code DefaultMeterObservationHandler}, the Timer). Otherwise the binder
+ * falls back to direct Timer recording. Per-UI state is stored as a UI
+ * attribute so concurrent UIs are tracked independently.
+ */
+final class NavigationMetricsBinder
+        implements BeforeEnterListener, AfterNavigationListener {
+
+    private static final String SAMPLE_KEY = NavigationMetricsBinder.class
+            .getName() + ".sample";
+    private static final String ROUTE_KEY = NavigationMetricsBinder.class
+            .getName() + ".route";
+    private static final String OBSERVATION_KEY = NavigationMetricsBinder.class
+            .getName() + ".observation";
+    private static final String OBSERVATION_SCOPE_KEY = NavigationMetricsBinder.class
+            .getName() + ".observation.scope";
+
+    private final MeterRegistry registry;
+    private final ObservationRegistry observationRegistry;
+    private final ObservabilitySettings config;
+    private final RouteTagResolver routes;
+
+    NavigationMetricsBinder(MeterRegistry registry, RouteTagResolver routes) {
+        this(registry, null, ObservabilitySettings.builder().build(), routes);
+    }
+
+    NavigationMetricsBinder(MeterRegistry registry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings config, RouteTagResolver routes) {
+        this.registry = registry;
+        this.observationRegistry = observationRegistry;
+        this.config = config;
+        this.routes = routes;
+    }
+
+    private boolean useObservation() {
+        return config.isTraces() && observationRegistry != null;
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        UI ui = event.getUI();
+        String route = routes.tagFor(event.getNavigationTarget());
+        ComponentUtil.setData(ui, ROUTE_KEY, route);
+        if (useObservation()) {
+            // Tell the enclosing request span this UIDL request navigated.
+            RequestInteraction.mark(ObservationNames.INTERACTION_NAVIGATION);
+            Observation obs = Observation
+                    .createNotStarted(MeterNames.NAVIGATION,
+                            observationRegistry)
+                    .contextualName(ObservationNames.NAVIGATION + " " + route)
+                    .lowCardinalityKeyValue(ObservationNames.KEY_ROUTE, route)
+                    .start();
+            ComponentUtil.setData(ui, OBSERVATION_KEY, obs);
+            ComponentUtil.setData(ui, OBSERVATION_SCOPE_KEY, obs.openScope());
+        } else {
+            ComponentUtil.setData(ui, SAMPLE_KEY, Timer.start(registry));
+        }
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        UI ui = UI.getCurrent();
+        if (ui == null) {
+            return;
+        }
+        Object sample = ComponentUtil.getData(ui, SAMPLE_KEY);
+        Object route = ComponentUtil.getData(ui, ROUTE_KEY);
+        Object obsObj = ComponentUtil.getData(ui, OBSERVATION_KEY);
+        Object scopeObj = ComponentUtil.getData(ui, OBSERVATION_SCOPE_KEY);
+        ComponentUtil.setData(ui, SAMPLE_KEY, null);
+        ComponentUtil.setData(ui, ROUTE_KEY, null);
+        ComponentUtil.setData(ui, OBSERVATION_KEY, null);
+        ComponentUtil.setData(ui, OBSERVATION_SCOPE_KEY, null);
+        if (sample instanceof Timer.Sample s) {
+            s.stop(registry.timer(MeterNames.NAVIGATION, MeterNames.TAG_ROUTE,
+                    route instanceof String r ? r : MeterNames.ROUTE_UNKNOWN,
+                    MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS));
+        }
+        if (scopeObj instanceof Observation.Scope scope) {
+            scope.close();
+        }
+        if (obsObj instanceof Observation obs) {
+            obs.lowCardinalityKeyValue(ObservationNames.KEY_OUTCOME,
+                    ObservationNames.OUTCOME_SUCCESS);
+            obs.stop();
+        }
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilityKit.java
@@ -8,9 +8,11 @@
  */
 package com.vaadin.observability.micrometer;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 
 /**
@@ -30,7 +32,15 @@ public final class ObservabilityKit {
 
     public static void install(MeterRegistry meterRegistry,
             ObservabilitySettings settings) {
-        install(meterRegistry, null, settings);
+        Objects.requireNonNull(meterRegistry, "meterRegistry");
+        Objects.requireNonNull(settings, "settings");
+        ObservationRegistry observationRegistry = null;
+        if (settings.isTraces()) {
+            observationRegistry = ObservationRegistry.create();
+            observationRegistry.observationConfig().observationHandler(
+                    new DefaultMeterObservationHandler(meterRegistry));
+        }
+        install(meterRegistry, observationRegistry, settings);
     }
 
     public static void install(MeterRegistry meterRegistry,

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/ObservabilitySettings.java
@@ -140,11 +140,21 @@ public final class ObservabilitySettings {
         }
 
         public Builder routeCardinalityLimit(int routeCardinalityLimit) {
+            if (routeCardinalityLimit < 1) {
+                throw new IllegalArgumentException(
+                        "routeCardinalityLimit must be >= 1, got "
+                                + routeCardinalityLimit);
+            }
             this.routeCardinalityLimit = routeCardinalityLimit;
             return this;
         }
 
         public Builder clientRatePerSession(int clientRatePerSession) {
+            if (clientRatePerSession < 0) {
+                throw new IllegalArgumentException(
+                        "clientRatePerSession must be >= 0, got "
+                                + clientRatePerSession);
+            }
             this.clientRatePerSession = clientRatePerSession;
             return this;
         }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestInteraction.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestInteraction.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+/**
+ * Thread-local relay that lets binders which observe a specific kind of
+ * server-side activity (poll, navigation) tell the {@code RequestMetricsBinder}
+ * what the in-flight UIDL request actually did.
+ * <p>
+ * UIDL processing is synchronous on the request thread, so a value set by a
+ * poll listener or navigation listener during request handling is visible to
+ * the interceptor's {@code requestEnd} on the same thread. The interceptor
+ * clears the slot at {@code requestStart} and consumes it at
+ * {@code requestEnd}.
+ */
+final class RequestInteraction {
+
+    private static final ThreadLocal<String> CURRENT = new ThreadLocal<>();
+
+    private RequestInteraction() {
+    }
+
+    /**
+     * Records what the current request did. Last writer wins; a request that
+     * both navigates and polls is rare and either label is acceptable.
+     */
+    static void mark(String kind) {
+        CURRENT.set(kind);
+    }
+
+    /**
+     * Returns and clears the interaction kind for the current thread, or
+     * {@code null} if none was marked.
+     */
+    static String take() {
+        String value = CURRENT.get();
+        CURRENT.remove();
+        return value;
+    }
+
+    /**
+     * Clears any value left over from a previous request on this (pooled)
+     * thread.
+     */
+    static void clear() {
+        CURRENT.remove();
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestMetricsBinder.java
@@ -85,6 +85,14 @@ final class RequestMetricsBinder implements VaadinRequestInterceptor {
 
     @Override
     public void requestStart(VaadinRequest request, VaadinResponse response) {
+        // Drop any stale thread-local state left by a previous request whose
+        // requestEnd was skipped (e.g. mid-request server shutdown). Without
+        // this a pooled thread could carry errored=TRUE into the next request
+        // and misreport it as an error.
+        errored.remove();
+        sample.remove();
+        observation.remove();
+        observationScope.remove();
         // Drop any interaction marker left by a previous request on this
         // pooled thread; poll/navigation listeners re-mark during handling.
         RequestInteraction.clear();
@@ -158,10 +166,21 @@ final class RequestMetricsBinder implements VaadinRequestInterceptor {
             return "/";
         }
         int queryStart = referer.indexOf('?', pathStart);
-        if (queryStart < 0) {
+        int fragmentStart = referer.indexOf('#', pathStart);
+        // pathEnd is the earliest of '?' and '#' (each only if present at or
+        // after pathStart), so hash-router URLs don't inflate tag cardinality.
+        int pathEnd = -1;
+        if (queryStart >= 0 && fragmentStart >= 0) {
+            pathEnd = Math.min(queryStart, fragmentStart);
+        } else if (queryStart >= 0) {
+            pathEnd = queryStart;
+        } else if (fragmentStart >= 0) {
+            pathEnd = fragmentStart;
+        }
+        if (pathEnd < 0) {
             return referer.substring(pathStart);
         }
-        return referer.substring(pathStart, queryStart);
+        return referer.substring(pathStart, pathEnd);
     }
 
     @Override

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestMetricsBinder.java
@@ -35,9 +35,7 @@ import com.vaadin.observability.micrometer.trace.ObservationNames;
  * the span-friendly name ({@code vaadin.request}) used by tracing
  * handlers.</li>
  * <li>Otherwise (no obs registry / traces disabled / observation handler
- * unavailable), the binder falls back to recording the Timer directly. This
- * keeps backward compatibility for standalone deployments that haven't
- * configured Observation.</li>
+ * unavailable), the binder falls back to recording the Timer directly.</li>
  * </ul>
  */
 final class RequestMetricsBinder implements VaadinRequestInterceptor {

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RequestMetricsBinder.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import java.util.function.BiConsumer;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinRequestInterceptor;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.observability.micrometer.trace.ObservationNames;
+
+/**
+ * Measures request duration and counts errors.
+ * <p>
+ * Two modes:
+ * <ul>
+ * <li>If {@code settings.isTraces()} and an {@link ObservationRegistry} is
+ * supplied, requests are driven through the Observation API. The Observation
+ * name matches the Timer name ({@link MeterNames#REQUEST_DURATION}) so a
+ * {@code DefaultMeterObservationHandler} produces the same Timer that the
+ * direct-recording path would. The Observation's {@code contextualName} carries
+ * the span-friendly name ({@code vaadin.request}) used by tracing
+ * handlers.</li>
+ * <li>Otherwise (no obs registry / traces disabled / observation handler
+ * unavailable), the binder falls back to recording the Timer directly. This
+ * keeps backward compatibility for standalone deployments that haven't
+ * configured Observation.</li>
+ * </ul>
+ */
+final class RequestMetricsBinder implements VaadinRequestInterceptor {
+
+    private static final BiConsumer<VaadinRequest, String> NO_ENRICH = (r,
+            t) -> {
+    };
+
+    private final MeterRegistry registry;
+    private final ObservationRegistry observationRegistry;
+    private final ObservabilitySettings settings;
+    private final BiConsumer<VaadinRequest, String> httpObservationEnricher;
+    private final ThreadLocal<Timer.Sample> sample = new ThreadLocal<>();
+    private final ThreadLocal<Boolean> errored = ThreadLocal
+            .withInitial(() -> Boolean.FALSE);
+    private final ThreadLocal<Observation> observation = new ThreadLocal<>();
+    private final ThreadLocal<Observation.Scope> observationScope = new ThreadLocal<>();
+
+    RequestMetricsBinder(MeterRegistry registry,
+            ObservabilitySettings settings) {
+        this(registry, null, settings, NO_ENRICH);
+    }
+
+    RequestMetricsBinder(MeterRegistry registry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings settings) {
+        this(registry, observationRegistry, settings, NO_ENRICH);
+    }
+
+    RequestMetricsBinder(MeterRegistry registry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings settings,
+            BiConsumer<VaadinRequest, String> httpObservationEnricher) {
+        this.registry = registry;
+        this.observationRegistry = observationRegistry;
+        this.settings = settings;
+        this.httpObservationEnricher = httpObservationEnricher != null
+                ? httpObservationEnricher
+                : NO_ENRICH;
+    }
+
+    private boolean useObservation() {
+        return settings.isTraces() && observationRegistry != null;
+    }
+
+    @Override
+    public void requestStart(VaadinRequest request, VaadinResponse response) {
+        // Drop any interaction marker left by a previous request on this
+        // pooled thread; poll/navigation listeners re-mark during handling.
+        RequestInteraction.clear();
+        if (useObservation()) {
+            String type = requestType(request);
+            // Let DI integrations (Spring/Boot) lift Vaadin type into the
+            // parent HTTP span so the trace UI shows the request type
+            // without drilling down. Defaults to no-op for standalone.
+            httpObservationEnricher.accept(request, type);
+            Observation obs = Observation
+                    .createNotStarted(MeterNames.REQUEST_DURATION,
+                            observationRegistry)
+                    .contextualName(ObservationNames.REQUEST + "." + type)
+                    .lowCardinalityKeyValue(ObservationNames.KEY_REQUEST_TYPE,
+                            type)
+                    .lowCardinalityKeyValue(ObservationNames.KEY_HTTP_METHOD,
+                            httpMethod(request))
+                    .lowCardinalityKeyValue(ObservationNames.KEY_UI_ID,
+                            uiId(request))
+                    .lowCardinalityKeyValue(
+                            ObservationNames.KEY_CLIENT_LOCATION,
+                            clientLocation(request))
+                    .start();
+            observation.set(obs);
+            observationScope.set(obs.openScope());
+        } else if (settings.isRequests()) {
+            sample.set(Timer.start(registry));
+        }
+    }
+
+    private static String httpMethod(VaadinRequest request) {
+        if (request == null) {
+            return "unknown";
+        }
+        String m = request.getMethod();
+        return m == null ? "unknown" : m;
+    }
+
+    private static String uiId(VaadinRequest request) {
+        if (request == null) {
+            return ObservationNames.UI_ID_UNKNOWN;
+        }
+        String id = request.getParameter("v-uiId");
+        return id != null ? id : ObservationNames.UI_ID_UNKNOWN;
+    }
+
+    /**
+     * Extracts the page path the UIDL request was sent from. Falls back to the
+     * Referer header path so we always emit something useful for dashboards
+     * filtering by view, without ever exposing PII (the path goes through the
+     * parent navigation observation's route template mapping in dashboards; we
+     * deliberately keep it un-templated here so the span captures the literal
+     * client path).
+     */
+    private static String clientLocation(VaadinRequest request) {
+        if (request == null) {
+            return ObservationNames.LOCATION_UNKNOWN;
+        }
+        String referer = request.getHeader("Referer");
+        if (referer == null || referer.isEmpty()) {
+            return ObservationNames.LOCATION_UNKNOWN;
+        }
+        // Strip scheme+host: keep just the path (and optional query) so
+        // tag cardinality stays modest and we never emit hostnames.
+        int schemeEnd = referer.indexOf("://");
+        if (schemeEnd < 0) {
+            return referer;
+        }
+        int pathStart = referer.indexOf('/', schemeEnd + 3);
+        if (pathStart < 0) {
+            return "/";
+        }
+        int queryStart = referer.indexOf('?', pathStart);
+        if (queryStart < 0) {
+            return referer.substring(pathStart);
+        }
+        return referer.substring(pathStart, queryStart);
+    }
+
+    @Override
+    public void handleException(VaadinRequest request, VaadinResponse response,
+            VaadinSession vaadinSession, Exception t) {
+        errored.set(Boolean.TRUE);
+        if (settings.isErrors() && t != null) {
+            Counter.builder(MeterNames.ERRORS)
+                    .tag(MeterNames.TAG_EXCEPTION, t.getClass().getSimpleName())
+                    .register(registry).increment();
+        }
+        Observation obs = observation.get();
+        if (obs != null && t != null) {
+            obs.error(t);
+        }
+    }
+
+    @Override
+    public void requestEnd(VaadinRequest request, VaadinResponse response,
+            VaadinSession session) {
+        boolean wasError = errored.get();
+        errored.remove();
+        String outcome = wasError ? MeterNames.OUTCOME_ERROR
+                : MeterNames.OUTCOME_SUCCESS;
+        Timer.Sample s = sample.get();
+        sample.remove();
+        if (s != null) {
+            s.stop(registry.timer(MeterNames.REQUEST_DURATION,
+                    MeterNames.TAG_OUTCOME, outcome));
+        }
+        Observation.Scope scope = observationScope.get();
+        observationScope.remove();
+        if (scope != null) {
+            scope.close();
+        }
+        Observation obs = observation.get();
+        observation.remove();
+        // Consume whatever a poll/navigation listener recorded for this
+        // request so the span name reflects what actually happened instead
+        // of the opaque protocol-level "uidl".
+        String interaction = RequestInteraction.take();
+        if (obs != null) {
+            String type = requestType(request);
+            if (ObservationNames.REQUEST_TYPE_UIDL.equals(type)) {
+                String kind = interaction != null ? interaction
+                        : ObservationNames.INTERACTION_RPC;
+                obs.lowCardinalityKeyValue(ObservationNames.KEY_INTERACTION,
+                        kind);
+                obs.contextualName(ObservationNames.REQUEST + "." + kind);
+            }
+            obs.lowCardinalityKeyValue(ObservationNames.KEY_OUTCOME, outcome);
+            obs.stop();
+        }
+    }
+
+    private static String requestType(VaadinRequest request) {
+        if (request == null) {
+            return ObservationNames.REQUEST_TYPE_OTHER;
+        }
+        String path = request.getPathInfo();
+        if (path != null) {
+            if (path.contains("/PUSH/")) {
+                return ObservationNames.REQUEST_TYPE_PUSH;
+            }
+            if (path.contains("/HEARTBEAT/")) {
+                return ObservationNames.REQUEST_TYPE_HEARTBEAT;
+            }
+        }
+        String vr = request.getParameter("v-r");
+        if ("uidl".equals(vr)) {
+            return ObservationNames.REQUEST_TYPE_UIDL;
+        }
+        if ("heartbeat".equals(vr)) {
+            return ObservationNames.REQUEST_TYPE_HEARTBEAT;
+        }
+        if (path != null && (path.startsWith("/VAADIN/")
+                || path.startsWith("/static/"))) {
+            return ObservationNames.REQUEST_TYPE_STATIC;
+        }
+        return ObservationNames.REQUEST_TYPE_OTHER;
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RouteTagResolver.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RouteTagResolver.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteConfiguration;
+
+/**
+ * Maps a Flow navigation target to a low-cardinality tag value suitable for
+ * Micrometer. Resolves the route template (e.g. {@code users/:id}) rather than
+ * the resolved URL, then enforces an upper bound on the number of distinct
+ * values it will admit; further values are bucketed under
+ * {@link MeterNames#ROUTE_OTHER}.
+ */
+public final class RouteTagResolver {
+
+    private final int limit;
+    private final Set<String> seen = ConcurrentHashMap.newKeySet();
+
+    public RouteTagResolver(int limit) {
+        this.limit = limit;
+    }
+
+    /**
+     * Resolves the tag value for a navigation target. {@code null} input is
+     * treated as an unknown route.
+     */
+    public String tagFor(Class<? extends Component> navigationTarget) {
+        if (navigationTarget == null) {
+            return MeterNames.ROUTE_UNKNOWN;
+        }
+        String template = resolveTemplate(navigationTarget)
+                .orElseGet(navigationTarget::getSimpleName);
+        if (seen.contains(template)) {
+            return template;
+        }
+        if (seen.size() < limit) {
+            seen.add(template);
+            return template;
+        }
+        return MeterNames.ROUTE_OTHER;
+    }
+
+    private Optional<String> resolveTemplate(
+            Class<? extends Component> navigationTarget) {
+        try {
+            return RouteConfiguration.forSessionScope()
+                    .getTemplate(navigationTarget);
+        } catch (RuntimeException ignored) {
+            // No current session bound; fall back to simple name.
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Bucketizes an already-resolved route template against the cardinality
+     * limit. Useful when the template is already known and we only need the
+     * overflow behavior.
+     */
+    public String tagForTemplate(String template) {
+        if (template == null) {
+            return MeterNames.ROUTE_UNKNOWN;
+        }
+        if (seen.contains(template)) {
+            return template;
+        }
+        if (seen.size() < limit) {
+            seen.add(template);
+            return template;
+        }
+        return MeterNames.ROUTE_OTHER;
+    }
+
+    int trackedCount() {
+        return seen.size();
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+
+import com.vaadin.flow.server.communication.RpcInvocationEvent;
+import com.vaadin.flow.server.communication.RpcInvocationListener;
+import com.vaadin.observability.micrometer.trace.ObservationNames;
+
+/**
+ * Measures server-side RPC invocation duration and records spans.
+ * <p>
+ * Two modes:
+ * <ul>
+ * <li>If {@code settings.isTraces()} and an {@link ObservationRegistry} is
+ * supplied, each RPC invocation is driven through the Observation API. The
+ * Observation name matches the Timer name ({@link MeterNames#RPC_DURATION}) so
+ * a {@code DefaultMeterObservationHandler} produces the same Timer that the
+ * direct-recording path would. The Observation's {@code contextualName} carries
+ * the span-friendly name ({@code vaadin.rpc.<type>}) used by tracing
+ * handlers.</li>
+ * <li>Otherwise (no obs registry / traces disabled / observation handler
+ * unavailable), the binder falls back to recording the Timer directly.</li>
+ * </ul>
+ * <p>
+ * Tags: {@code type} (RPC invocation type) and {@code outcome}
+ * ({@code success}/{@code error}). The invocation name and node ID are
+ * deliberately omitted because they are high-cardinality.
+ */
+final class RpcMetricsBinder implements RpcInvocationListener {
+
+    private final MeterRegistry registry;
+    private final ObservationRegistry observationRegistry;
+    private final boolean useObservation;
+
+    private final ThreadLocal<Boolean> errored = ThreadLocal
+            .withInitial(() -> Boolean.FALSE);
+    private final ThreadLocal<Timer.Sample> sample = new ThreadLocal<>();
+    private final ThreadLocal<Observation> observation = new ThreadLocal<>();
+    private final ThreadLocal<Observation.Scope> observationScope = new ThreadLocal<>();
+
+    RpcMetricsBinder(MeterRegistry registry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings settings) {
+        this.registry = registry;
+        this.observationRegistry = observationRegistry;
+        this.useObservation = observationRegistry != null
+                && settings.isTraces();
+    }
+
+    @Override
+    public void invocationStarted(RpcInvocationEvent event) {
+        // Defensively clear any stale thread-local state left by a previous
+        // invocation whose invocationEnded was skipped (e.g. mid-request
+        // server shutdown). Without this, a pooled thread could carry
+        // errored=TRUE into the next invocation and misreport it.
+        errored.remove();
+        sample.remove();
+        observation.remove();
+        observationScope.remove();
+
+        // Mark the enclosing UIDL request span as an RPC interaction so the
+        // RequestMetricsBinder labels the parent span appropriately.
+        RequestInteraction.mark(ObservationNames.INTERACTION_RPC);
+
+        String type = event.getType();
+        if (useObservation) {
+            Observation obs = Observation
+                    .createNotStarted(MeterNames.RPC_DURATION,
+                            observationRegistry)
+                    .contextualName(ObservationNames.RPC + "." + type)
+                    .lowCardinalityKeyValue(MeterNames.TAG_TYPE, type).start();
+            observation.set(obs);
+            observationScope.set(obs.openScope());
+        } else {
+            sample.set(Timer.start(registry));
+        }
+    }
+
+    @Override
+    public void invocationFailed(RpcInvocationEvent event, Throwable error) {
+        errored.set(Boolean.TRUE);
+        Observation obs = observation.get();
+        if (obs != null && error != null) {
+            obs.error(error);
+        }
+    }
+
+    @Override
+    public void invocationEnded(RpcInvocationEvent event) {
+        boolean wasError = errored.get();
+        String outcome = wasError ? MeterNames.OUTCOME_ERROR
+                : MeterNames.OUTCOME_SUCCESS;
+        String type = event.getType();
+
+        Timer.Sample s = sample.get();
+        Observation.Scope scope = observationScope.get();
+        Observation obs = observation.get();
+
+        // Clear all thread-locals before any calls that could throw.
+        errored.remove();
+        sample.remove();
+        observationScope.remove();
+        observation.remove();
+
+        if (obs != null) {
+            obs.lowCardinalityKeyValue(MeterNames.TAG_OUTCOME, outcome);
+            if (scope != null) {
+                scope.close();
+            }
+            obs.stop();
+        } else if (s != null) {
+            s.stop(Timer.builder(MeterNames.RPC_DURATION)
+                    .tag(MeterNames.TAG_TYPE, type)
+                    .tag(MeterNames.TAG_OUTCOME, outcome).register(registry));
+        }
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
@@ -114,7 +114,7 @@ final class RpcMetricsBinder implements RpcInvocationListener {
         observation.remove();
 
         if (obs != null) {
-            obs.lowCardinalityKeyValue(MeterNames.TAG_OUTCOME, outcome);
+            obs.lowCardinalityKeyValue(ObservationNames.KEY_OUTCOME, outcome);
             if (scope != null) {
                 scope.close();
             }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionLockMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionLockMetricsBinder.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import java.time.Duration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import com.vaadin.flow.server.SessionLockEvent;
+import com.vaadin.flow.server.SessionLockListener;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Records session-lock wait and hold times from Flow's
+ * {@link SessionLockListener} SPI.
+ * <p>
+ * Vaadin serializes all server-side work for a session behind one lock, so
+ * {@code vaadin.session.lock.wait} (time blocked acquiring the lock) is the
+ * session-contention signal, and {@code vaadin.session.lock.hold} (time the
+ * lock was held) is how long each unit of work monopolized the session. The
+ * {@code context} tag distinguishes request-thread acquisitions from
+ * {@code UI.access}/background acquisitions.
+ * <p>
+ * The SPI delivers {@code lockRequested} → {@code lockAcquired} →
+ * {@code lockReleased} on the same thread for one outermost hold, so wait and
+ * hold start times are kept in thread locals.
+ */
+final class SessionLockMetricsBinder implements SessionLockListener {
+
+    private final MeterRegistry registry;
+    private final transient ThreadLocal<Long> waitStart = new ThreadLocal<>();
+    private final transient ThreadLocal<Long> holdStart = new ThreadLocal<>();
+
+    SessionLockMetricsBinder(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void lockRequested(SessionLockEvent event) {
+        waitStart.set(System.nanoTime());
+    }
+
+    @Override
+    public void lockAcquired(SessionLockEvent event) {
+        long now = System.nanoTime();
+        Long started = waitStart.get();
+        waitStart.remove();
+        String context = context();
+        if (started != null) {
+            registry.timer(MeterNames.SESSION_LOCK_WAIT, MeterNames.TAG_CONTEXT,
+                    context).record(Duration.ofNanos(now - started));
+        }
+        holdStart.set(now);
+    }
+
+    @Override
+    public void lockReleased(SessionLockEvent event) {
+        long now = System.nanoTime();
+        Long started = holdStart.get();
+        holdStart.remove();
+        if (started != null) {
+            registry.timer(MeterNames.SESSION_LOCK_HOLD, MeterNames.TAG_CONTEXT,
+                    context()).record(Duration.ofNanos(now - started));
+        }
+    }
+
+    /**
+     * Best-effort classification: a lock taken while a Vaadin request is
+     * current is attributed to request handling, otherwise to a
+     * {@code UI.access}/background acquisition.
+     */
+    private static String context() {
+        return VaadinService.getCurrentRequest() != null
+                ? MeterNames.CONTEXT_REQUEST
+                : MeterNames.CONTEXT_ACCESS;
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.server.VaadinSession;
  * Tracks session lifecycle metrics: cumulative count, currently-active count,
  * and per-session lifetime.
  */
-class SessionMetricsBinder
+final class SessionMetricsBinder
         implements SessionInitListener, SessionDestroyListener {
 
     private final Counter created;

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/SessionMetricsBinder.java
@@ -8,40 +8,56 @@
  */
 package com.vaadin.observability.micrometer;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 
 import com.vaadin.flow.server.SessionDestroyEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitEvent;
 import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.VaadinSession;
 
 /**
- * Tracks the number of active Vaadin sessions as a gauge. Register the same
- * instance as both a {@link SessionInitListener} and a
- * {@link SessionDestroyListener} on the {@code VaadinService}.
+ * Tracks session lifecycle metrics: cumulative count, currently-active count,
+ * and per-session lifetime.
  */
 class SessionMetricsBinder
         implements SessionInitListener, SessionDestroyListener {
 
-    private final AtomicInteger activeSessions = new AtomicInteger();
+    private final Counter created;
+    private final AtomicLong active = new AtomicLong();
+    private final Timer duration;
+    private final Map<VaadinSession, Long> startNanos = new ConcurrentHashMap<>();
 
     SessionMetricsBinder(MeterRegistry registry) {
-        Gauge.builder(MeterNames.SESSIONS_ACTIVE, activeSessions,
-                AtomicInteger::doubleValue)
-                .description("Number of active Vaadin sessions")
+        this.created = Counter.builder(MeterNames.SESSIONS_CREATED)
+                .register(registry);
+        Gauge.builder(MeterNames.SESSIONS_ACTIVE, active, AtomicLong::get)
+                .register(registry);
+        this.duration = Timer.builder(MeterNames.SESSIONS_DURATION)
                 .register(registry);
     }
 
     @Override
     public void sessionInit(SessionInitEvent event) {
-        activeSessions.incrementAndGet();
+        created.increment();
+        active.incrementAndGet();
+        startNanos.put(event.getSession(), System.nanoTime());
     }
 
     @Override
     public void sessionDestroy(SessionDestroyEvent event) {
-        activeSessions.decrementAndGet();
+        Long start = startNanos.remove(event.getSession());
+        active.decrementAndGet();
+        if (start != null) {
+            duration.record(Duration.ofNanos(System.nanoTime() - start));
+        }
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/UiMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/UiMetricsBinder.java
@@ -18,6 +18,8 @@ import io.micrometer.observation.ObservationRegistry;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.UIInitEvent;
 import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.observability.micrometer.client.ClientMetricsBinder;
+import com.vaadin.observability.micrometer.client.MetricsCollectorElement;
 import com.vaadin.observability.micrometer.trace.ObservationNames;
 
 /**
@@ -32,6 +34,7 @@ final class UiMetricsBinder implements UIInitListener {
     private final Counter created;
     private final AtomicLong active = new AtomicLong();
     private final NavigationMetricsBinder navigationBinder;
+    private final ClientMetricsBinder clientBinder;
 
     UiMetricsBinder(MeterRegistry registry,
             ObservationRegistry observationRegistry,
@@ -48,6 +51,9 @@ final class UiMetricsBinder implements UIInitListener {
                         settings,
                         new RouteTagResolver(
                                 settings.getRouteCardinalityLimit()))
+                : null;
+        this.clientBinder = settings.isClient()
+                ? new ClientMetricsBinder(registry, settings)
                 : null;
     }
 
@@ -70,6 +76,8 @@ final class UiMetricsBinder implements UIInitListener {
             ui.addPollListener(e -> RequestInteraction
                     .mark(ObservationNames.INTERACTION_POLL));
         }
-        // TODO(P2-T9): wire client metrics collector when isClient()
+        if (clientBinder != null) {
+            ui.add(new MetricsCollectorElement(clientBinder, settings));
+        }
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/UiMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/UiMetricsBinder.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.UIInitEvent;
+import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.observability.micrometer.trace.ObservationNames;
+
+/**
+ * Tracks per-UI lifecycle metrics and, when navigation metrics are enabled,
+ * attaches a {@link NavigationMetricsBinder} to each newly initialized UI.
+ */
+final class UiMetricsBinder implements UIInitListener {
+
+    private final MeterRegistry registry;
+    private final ObservationRegistry observationRegistry;
+    private final ObservabilitySettings settings;
+    private final Counter created;
+    private final AtomicLong active = new AtomicLong();
+    private final NavigationMetricsBinder navigationBinder;
+
+    UiMetricsBinder(MeterRegistry registry,
+            ObservationRegistry observationRegistry,
+            ObservabilitySettings settings) {
+        this.registry = registry;
+        this.observationRegistry = observationRegistry;
+        this.settings = settings;
+        this.created = Counter.builder(MeterNames.UI_CREATED)
+                .register(registry);
+        Gauge.builder(MeterNames.UI_ACTIVE, active, AtomicLong::get)
+                .register(registry);
+        this.navigationBinder = settings.isNavigation()
+                ? new NavigationMetricsBinder(registry, observationRegistry,
+                        settings,
+                        new RouteTagResolver(
+                                settings.getRouteCardinalityLimit()))
+                : null;
+    }
+
+    @Override
+    public void uiInit(UIInitEvent event) {
+        UI ui = event.getUI();
+        if (settings.isUis()) {
+            created.increment();
+            active.incrementAndGet();
+            ui.addDetachListener(e -> active.decrementAndGet());
+        }
+        if (navigationBinder != null) {
+            ui.addBeforeEnterListener(navigationBinder);
+            ui.addAfterNavigationListener(navigationBinder);
+        }
+        if (settings.isTraces() && observationRegistry != null) {
+            // Polls are the high-frequency UIDL noise; labelling them lets the
+            // request span read "vaadin.request.poll" instead of an opaque
+            // "vaadin.request.uidl".
+            ui.addPollListener(e -> RequestInteraction
+                    .mark(ObservationNames.INTERACTION_POLL));
+        }
+        // TODO(P2-T9): wire client metrics collector when isClient()
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientMetricNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientMetricNames.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+import java.util.Set;
+
+import com.vaadin.observability.micrometer.MeterNames;
+
+/**
+ * Allowlist of client-emitted meter names. Samples whose names are not in this
+ * set are dropped at ingest time, capping cardinality from malicious or buggy
+ * clients.
+ *
+ * <p>
+ * Note: {@link MeterNames#CLIENT_RPC_DURATION} is intentionally excluded from
+ * {@link #ALLOWED} because RPC timing is measured server-side only.
+ */
+final class ClientMetricNames {
+
+    static final Set<String> ALLOWED = Set.of(
+            MeterNames.CLIENT_BOOTSTRAP_DURATION,
+            MeterNames.CLIENT_NAVIGATION_DURATION,
+            MeterNames.CLIENT_WEB_VITALS_LCP, MeterNames.CLIENT_WEB_VITALS_FCP,
+            MeterNames.CLIENT_ERRORS);
+
+    static final Set<String> COUNTER_NAMES = Set.of(MeterNames.CLIENT_ERRORS);
+
+    static boolean isAllowed(String name) {
+        return name != null && ALLOWED.contains(name);
+    }
+
+    static boolean isCounter(String name) {
+        return COUNTER_NAMES.contains(name);
+    }
+
+    private ClientMetricNames() {
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientMetricsBinder.java
@@ -93,11 +93,11 @@ public final class ClientMetricsBinder {
             if (key.length() > MAX_TAG_KEY_LEN) {
                 continue;
             }
-            if (value.length() > MAX_TAG_VALUE_LEN) {
-                value = MeterNames.ROUTE_OTHER;
-            }
             if (MeterNames.TAG_ROUTE.equals(key)) {
                 value = templateRoute(value);
+            }
+            if (value.length() > MAX_TAG_VALUE_LEN) {
+                value = MeterNames.ROUTE_OTHER;
             }
             out.add(key);
             out.add(value);

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientMetricsBinder.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.observability.micrometer.MeterNames;
+import com.vaadin.observability.micrometer.ObservabilitySettings;
+import com.vaadin.observability.micrometer.RouteTagResolver;
+
+/**
+ * Validates and records samples emitted by the in-browser collector.
+ * <p>
+ * Applies the metric-name allowlist, route-template resolution against the
+ * current session's {@link RouteConfiguration}, cardinality capping via
+ * {@link RouteTagResolver}, and bounded-length tag validation.
+ */
+public final class ClientMetricsBinder {
+
+    private static final int MAX_TAG_KEY_LEN = 64;
+    private static final int MAX_TAG_VALUE_LEN = 200;
+    private static final String[] EMPTY = new String[0];
+
+    private final MeterRegistry registry;
+    private final RouteTagResolver routes;
+
+    public ClientMetricsBinder(MeterRegistry registry,
+            ObservabilitySettings settings) {
+        this.registry = registry;
+        this.routes = new RouteTagResolver(settings.getRouteCardinalityLimit());
+    }
+
+    public void ingest(List<ClientSample> samples) {
+        if (samples == null) {
+            return;
+        }
+        for (ClientSample sample : samples) {
+            String name = sample.getName();
+            if (!ClientMetricNames.isAllowed(name)) {
+                continue;
+            }
+            String[] tags = buildTags(sample);
+            if (ClientMetricNames.isCounter(name)) {
+                registry.counter(name, tags).increment();
+            } else {
+                long nanos = (long) (sample.getValueMs() * 1_000_000.0);
+                if (nanos < 0) {
+                    continue;
+                }
+                registry.timer(name, tags).record(Duration.ofNanos(nanos));
+            }
+        }
+    }
+
+    public void recordDropped(int count) {
+        if (count > 0) {
+            registry.counter(MeterNames.CLIENT_DROPPED).increment(count);
+        }
+    }
+
+    public void recordThrottled(int count) {
+        if (count > 0) {
+            registry.counter(MeterNames.CLIENT_THROTTLED).increment(count);
+        }
+    }
+
+    private String[] buildTags(ClientSample sample) {
+        Map<String, String> raw = sample.getTags();
+        if (raw == null || raw.isEmpty()) {
+            return EMPTY;
+        }
+        List<String> out = new ArrayList<>(raw.size() * 2);
+        for (Map.Entry<String, String> entry : raw.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (key == null || value == null || key.isEmpty()) {
+                continue;
+            }
+            if (key.length() > MAX_TAG_KEY_LEN) {
+                continue;
+            }
+            if (value.length() > MAX_TAG_VALUE_LEN) {
+                value = MeterNames.ROUTE_OTHER;
+            }
+            if (MeterNames.TAG_ROUTE.equals(key)) {
+                value = templateRoute(value);
+            }
+            out.add(key);
+            out.add(value);
+        }
+        return out.toArray(new String[0]);
+    }
+
+    private String templateRoute(String rawPath) {
+        if (rawPath == null) {
+            return MeterNames.ROUTE_UNKNOWN;
+        }
+        String path = rawPath;
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        try {
+            RouteConfiguration rc = RouteConfiguration.forSessionScope();
+            Optional<Class<? extends Component>> target = rc.getRoute(path);
+            if (target.isPresent()) {
+                Optional<String> template = rc.getTemplate(target.get());
+                if (template.isPresent()) {
+                    return routes.tagForTemplate(template.get());
+                }
+                return routes.tagFor(target.get());
+            }
+        } catch (RuntimeException ignored) {
+            // no session in scope or registry not initialized
+        }
+        return MeterNames.ROUTE_UNKNOWN;
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientRateLimiter.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientRateLimiter.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+/**
+ * Trivial token bucket: refills {@code ratePerWindow} tokens every
+ * {@code windowMs} milliseconds. Not thread safe in the strict sense, but
+ * synchronized on the instance, which is sufficient because there is one
+ * limiter per UI.
+ */
+final class ClientRateLimiter {
+
+    private static final long WINDOW_MS = 10_000L;
+
+    private final int ratePerWindow;
+    private long windowStart;
+    private int consumed;
+
+    ClientRateLimiter(int ratePerWindow) {
+        this.ratePerWindow = ratePerWindow;
+        this.windowStart = System.currentTimeMillis();
+    }
+
+    /**
+     * Attempts to consume {@code n} tokens. Returns the number actually granted
+     * (between 0 and {@code n}); the caller must drop any samples beyond that.
+     */
+    synchronized int tryAcquire(int n) {
+        if (ratePerWindow <= 0) {
+            return n;
+        }
+        long now = System.currentTimeMillis();
+        if (now - windowStart >= WINDOW_MS) {
+            windowStart = now;
+            consumed = 0;
+        }
+        int remaining = Math.max(0, ratePerWindow - consumed);
+        int granted = Math.min(n, remaining);
+        consumed += granted;
+        return granted;
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientSample.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/ClientSample.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * One client-side measurement, deserialized by Flow's JSON codec from the
+ * browser-side collector.
+ */
+public class ClientSample implements Serializable {
+
+    private String name;
+    private Map<String, String> tags;
+    private double valueMs;
+    private long ts;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, String> getTags() {
+        return tags == null ? Collections.emptyMap() : tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    public double getValueMs() {
+        return valueMs;
+    }
+
+    public void setValueMs(double valueMs) {
+        this.valueMs = valueMs;
+    }
+
+    public long getTs() {
+        return ts;
+    }
+
+    public void setTs(long ts) {
+        this.ts = ts;
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/MetricsCollectorElement.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/MetricsCollectorElement.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import com.vaadin.observability.micrometer.ObservabilitySettings;
+
+/**
+ * Hidden helper component attached to each UI when client metrics are enabled.
+ * Exposes a {@link ClientCallable} that receives batches of
+ * {@link ClientSample} from the in-browser collector. Loads the client JS on
+ * first attach and re-attaches itself to its UI if removed.
+ */
+@Tag("vaadin-metrics-collector")
+public final class MetricsCollectorElement extends Component {
+
+    private static final String CLIENT_INIT_KEY = "vaadinMetricsClientInitialized";
+    private static final String CLIENT_RESOURCE = "META-INF/frontend/VaadinMetricsClient.js";
+
+    private final transient ClientMetricsBinder binder;
+    private final transient ClientRateLimiter limiter;
+
+    public MetricsCollectorElement(ClientMetricsBinder binder,
+            ObservabilitySettings settings) {
+        this.binder = binder;
+        this.limiter = new ClientRateLimiter(
+                settings.getClientRatePerSession());
+        getElement().getStyle().set("display", "none");
+        addDetachListener(event -> {
+            UI ui = event.getUI();
+            if (ui != null && !ui.isClosing()) {
+                ui.access(() -> ui.add(this));
+            }
+        });
+    }
+
+    @Override
+    protected void onAttach(AttachEvent event) {
+        ensureClientLoaded(event.getUI());
+    }
+
+    @ClientCallable
+    public void recordSamples(List<ClientSample> samples) {
+        if (binder == null || samples == null || samples.isEmpty()) {
+            return;
+        }
+        int granted = limiter.tryAcquire(samples.size());
+        if (granted < samples.size()) {
+            binder.recordThrottled(samples.size() - granted);
+            if (granted == 0) {
+                return;
+            }
+            binder.ingest(samples.subList(0, granted));
+        } else {
+            binder.ingest(samples);
+        }
+    }
+
+    private static void ensureClientLoaded(UI ui) {
+        if (ComponentUtil.getData(ui, CLIENT_INIT_KEY) != null) {
+            return;
+        }
+        ComponentUtil.setData(ui, CLIENT_INIT_KEY, Boolean.TRUE);
+        ClassLoader loader = MetricsCollectorElement.class.getClassLoader();
+        try (InputStream in = loader.getResourceAsStream(CLIENT_RESOURCE)) {
+            if (in == null) {
+                LoggerFactory.getLogger(MetricsCollectorElement.class).warn(
+                        "observability-kit client resource not found: {}",
+                        CLIENT_RESOURCE);
+                return;
+            }
+            String js = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            ui.getPage().executeJs(js);
+        } catch (IOException e) {
+            LoggerFactory.getLogger(MetricsCollectorElement.class)
+                    .warn("Could not load observability-kit client code", e);
+        }
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/MetricsCollectorElement.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/client/MetricsCollectorElement.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.observability.micrometer.ObservabilitySettings;
 
 /**
@@ -87,7 +88,9 @@ public final class MetricsCollectorElement extends Component {
                         CLIENT_RESOURCE);
                 return;
             }
-            String js = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            String js = StringUtil.removeComments(
+                    new String(in.readAllBytes(), StandardCharsets.UTF_8),
+                    true);
             ui.getPage().executeJs(js);
         } catch (IOException e) {
             LoggerFactory.getLogger(MetricsCollectorElement.class)

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2026 Vaadin Ltd
+ * Copyright (C) 2000-2026 Vaadin Ltd
  *
  * This program is available under Vaadin Commercial License and Service Terms.
  *

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.trace;
+
+/**
+ * Span name + attribute-key constants for Observability Kit Observations.
+ * <p>
+ * Span names follow Micrometer/OpenTelemetry conventions (lowercase
+ * dot-separated). They are intentionally distinct from the parallel Meter names
+ * (e.g. {@code vaadin.request} span vs. {@code vaadin.request.duration} timer)
+ * so that auto-Timer producers like {@code DefaultMeterObservationHandler} do
+ * not collide with the existing manual timers emitted by the binders.
+ */
+public final class ObservationNames {
+
+    public static final String REQUEST = "vaadin.request";
+    public static final String NAVIGATION = "vaadin.navigation";
+    public static final String UI_ACCESS = "vaadin.ui.access";
+
+    public static final String KEY_OUTCOME = "outcome";
+    public static final String KEY_REQUEST_TYPE = "vaadin.request.type";
+    public static final String KEY_INTERACTION = "vaadin.interaction";
+    public static final String KEY_ROUTE = "route";
+    public static final String KEY_HTTP_METHOD = "http.method";
+    public static final String KEY_SESSION_ID = "vaadin.session.id";
+    public static final String KEY_UI_ID = "ui.id";
+    public static final String KEY_CLIENT_LOCATION = "vaadin.client.location";
+
+    /** A poll request triggered by a configured poll interval. */
+    public static final String INTERACTION_POLL = "poll";
+
+    /** The request performed a server-side navigation. */
+    public static final String INTERACTION_NAVIGATION = "navigation";
+
+    /**
+     * A real client-to-server RPC (DOM event, {@code @ClientCallable}, property
+     * sync, return channel) that we cannot break down further without parsing
+     * the UIDL body.
+     */
+    public static final String INTERACTION_RPC = "rpc";
+
+    public static final String UI_ID_UNKNOWN = "_unknown";
+    public static final String LOCATION_UNKNOWN = "_unknown";
+
+    public static final String OUTCOME_SUCCESS = "success";
+    public static final String OUTCOME_ERROR = "error";
+
+    public static final String REQUEST_TYPE_UIDL = "uidl";
+    public static final String REQUEST_TYPE_HEARTBEAT = "heartbeat";
+    public static final String REQUEST_TYPE_PUSH = "push";
+    public static final String REQUEST_TYPE_STATIC = "static";
+    public static final String REQUEST_TYPE_OTHER = "other";
+
+    /** Observation/span name for a server-side RPC invocation. */
+    public static final String RPC = "vaadin.rpc";
+
+    private ObservationNames() {
+    }
+}

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/TracingExecutor.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/TracingExecutor.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.trace;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+
+/**
+ * Wraps a Vaadin service {@link Executor} so that
+ * <ol>
+ * <li>the trace context (and any other
+ * {@link io.micrometer.context.ThreadLocalAccessor}-backed state) active when a
+ * task is <em>submitted</em> is restored when the task <em>runs</em>; and</li>
+ * <li>each task gets its own {@code vaadin.ui.access} span when an
+ * {@link ObservationRegistry} is supplied. The span is parented to the
+ * propagated trace, so a click that schedules a {@code UI.access(...)} ends up
+ * with a continuous trace tree across thread hops.</li>
+ * </ol>
+ */
+public final class TracingExecutor implements Executor {
+
+    private final Executor delegate;
+    private final ObservationRegistry observationRegistry;
+    private final ContextSnapshotFactory snapshotFactory;
+
+    public TracingExecutor(Executor delegate) {
+        this(delegate, null);
+    }
+
+    public TracingExecutor(Executor delegate,
+            ObservationRegistry observationRegistry) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.observationRegistry = observationRegistry;
+        this.snapshotFactory = ContextSnapshotFactory.builder().build();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        ContextSnapshot snapshot = snapshotFactory.captureAll();
+        delegate.execute(snapshot.wrap(() -> {
+            if (observationRegistry == null) {
+                command.run();
+                return;
+            }
+            Observation observation = Observation
+                    .createNotStarted(ObservationNames.UI_ACCESS,
+                            observationRegistry)
+                    .contextualName(ObservationNames.UI_ACCESS).start();
+            try (Observation.Scope ignored = observation.openScope()) {
+                command.run();
+            } catch (Throwable t) {
+                observation.error(t);
+                throw t;
+            } finally {
+                observation.stop();
+            }
+        }));
+    }
+
+    /** Exposed for tests. */
+    Executor delegate() {
+        return delegate;
+    }
+}

--- a/observability-kit-micrometer/src/main/resources/META-INF/frontend/VaadinMetricsClient.js
+++ b/observability-kit-micrometer/src/main/resources/META-INF/frontend/VaadinMetricsClient.js
@@ -1,0 +1,162 @@
+// Copyright 2000-2026 Vaadin Ltd.
+// Licensed under the Vaadin Commercial License and Service Terms.
+//
+// In-browser collector for observability-kit. Injected per UI by
+// MetricsCollectorElement via Page.executeJs. The IIFE is idempotent so the
+// re-attach path does not double-install hooks.
+(function () {
+  if (window.__vaadinMicrometerInstalled) {
+    return;
+  }
+  window.__vaadinMicrometerInstalled = true;
+
+  var COLLECTOR_TAG = 'vaadin-metrics-collector';
+  var BUFFER_MAX = 200;
+  var FLUSH_INTERVAL_MS = 5000;
+
+  var buffer = [];
+
+  function pushSample(name, tags, valueMs) {
+    if (typeof valueMs !== 'number' || isNaN(valueMs) || valueMs < 0) {
+      valueMs = 0;
+    }
+    if (buffer.length >= BUFFER_MAX) {
+      buffer.shift();
+    }
+    buffer.push({
+      name: name,
+      tags: tags || {},
+      valueMs: valueMs,
+      ts: Date.now()
+    });
+  }
+
+  function currentRoute() {
+    return window.location.pathname || '/';
+  }
+
+  function flush() {
+    if (buffer.length === 0) {
+      return;
+    }
+    var el = document.querySelector(COLLECTOR_TAG);
+    if (!el || !el.$server || typeof el.$server.recordSamples !== 'function') {
+      return;
+    }
+    var batch = buffer.splice(0, buffer.length);
+    try {
+      el.$server.recordSamples(batch);
+    } catch (e) {
+      // server unreachable: drop this batch, do not requeue to avoid
+      // unbounded buffer growth on persistent failure.
+    }
+  }
+
+  // Bootstrap timing.
+  try {
+    var navEntries = performance.getEntriesByType('navigation');
+    if (navEntries && navEntries.length > 0) {
+      var nav = navEntries[0];
+      var dur =
+        nav.loadEventEnd > 0 ? nav.loadEventEnd - nav.fetchStart : nav.domContentLoadedEventEnd - nav.fetchStart;
+      if (dur > 0) {
+        pushSample('vaadin.client.bootstrap.duration', { route: currentRoute() }, dur);
+      }
+    }
+  } catch (e) {
+    /* ignore */
+  }
+
+  // Web Vitals: LCP.
+  try {
+    var lcpObserver = new PerformanceObserver(function (list) {
+      var entries = list.getEntries();
+      var last = entries[entries.length - 1];
+      if (last) {
+        var value = last.renderTime || last.loadTime || last.startTime;
+        pushSample('vaadin.client.web_vitals.lcp', { route: currentRoute() }, value);
+      }
+    });
+    lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
+  } catch (e) {
+    /* unsupported, skip */
+  }
+
+  // Web Vitals: FCP (from paint timing).
+  try {
+    var paintObserver = new PerformanceObserver(function (list) {
+      list.getEntries().forEach(function (entry) {
+        if (entry.name === 'first-contentful-paint') {
+          pushSample('vaadin.client.web_vitals.fcp', { route: currentRoute() }, entry.startTime);
+        }
+      });
+    });
+    paintObserver.observe({ type: 'paint', buffered: true });
+  } catch (e) {
+    /* unsupported, skip */
+  }
+
+  // Errors.
+  window.addEventListener('error', function () {
+    pushSample('vaadin.client.errors', { kind: 'uncaught' }, 0);
+  });
+  window.addEventListener('unhandledrejection', function () {
+    pushSample('vaadin.client.errors', { kind: 'promise' }, 0);
+  });
+
+  // Navigation timing: observe history changes.
+  var navStart = null;
+  function startNav() {
+    navStart = performance.now();
+  }
+  function endNav(trigger) {
+    if (navStart === null) {
+      return;
+    }
+    var duration = performance.now() - navStart;
+    navStart = null;
+    pushSample('vaadin.client.navigation.duration', { route: currentRoute(), trigger: trigger }, duration);
+  }
+  try {
+    window.addEventListener('popstate', function () {
+      startNav();
+      // navigation completes by the next animation frame typically; the
+      // route path is already updated by the time popstate fires.
+      requestAnimationFrame(function () {
+        endNav('back');
+      });
+    });
+    // Wrap pushState / replaceState to detect programmatic navigation.
+    ['pushState', 'replaceState'].forEach(function (op) {
+      var orig = history[op];
+      history[op] = function () {
+        startNav();
+        var result = orig.apply(this, arguments);
+        requestAnimationFrame(function () {
+          endNav('programmatic');
+        });
+        return result;
+      };
+    });
+  } catch (e) {
+    /* ignore */
+  }
+
+  // Periodic flush.
+  setInterval(flush, FLUSH_INTERVAL_MS);
+
+  // Visibility flush: best-effort, no Beacon fallback in v1.
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'hidden') {
+      flush();
+    }
+  });
+
+  // Expose for tests / dashboards (debug only).
+  window.__vaadinMicrometer = {
+    flush: flush,
+    bufferSize: function () {
+      return buffer.length;
+    }
+  };
+})();

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -105,10 +105,10 @@ class MetricsServiceInitListenerTest {
     }
 
     @Test
-    void skipsUiInitListenerWhenUisAndNavigationDisabled() {
+    void skipsUiInitListenerWhenUisAndNavigationAndClientDisabled() {
         ObservabilityKit.install(new SimpleMeterRegistry(),
                 ObservabilitySettings.builder().uis(false).navigation(false)
-                        .build());
+                        .client(false).build());
         VaadinService service = mock(VaadinService.class);
         ServiceInitEvent event = mock(ServiceInitEvent.class);
         when(event.getSource()).thenReturn(service);
@@ -116,6 +116,20 @@ class MetricsServiceInitListenerTest {
         new MetricsServiceInitListener().serviceInit(event);
 
         verify(service, never()).addUIInitListener(any());
+    }
+
+    @Test
+    void registersUiInitListenerWhenOnlyClientEnabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().uis(false).navigation(false)
+                        .client(true).build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service).addUIInitListener(any(UIInitListener.class));
     }
 
     @Test

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -17,6 +17,7 @@ import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitListener;
 import com.vaadin.flow.server.SessionLockListener;
 import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.flow.server.VaadinRequestInterceptor;
 import com.vaadin.flow.server.VaadinService;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -114,5 +115,48 @@ class MetricsServiceInitListenerTest {
         new MetricsServiceInitListener().serviceInit(event);
 
         verify(service, never()).addUIInitListener(any());
+    }
+
+    @Test
+    void registersRequestInterceptorWhenRequestsEnabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(event).addVaadinRequestInterceptor(
+                any(VaadinRequestInterceptor.class));
+    }
+
+    @Test
+    void registersRequestInterceptorWhenOnlyErrorsEnabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().requests(false).errors(true)
+                        .build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(event).addVaadinRequestInterceptor(
+                any(VaadinRequestInterceptor.class));
+    }
+
+    @Test
+    void skipsRequestInterceptorWhenRequestsAndErrorsDisabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().requests(false).errors(false)
+                        .build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(event, never()).addVaadinRequestInterceptor(any());
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -16,6 +16,7 @@ import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitListener;
 import com.vaadin.flow.server.SessionLockListener;
+import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinService;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -72,5 +73,46 @@ class MetricsServiceInitListenerTest {
         verify(service, never()).addSessionInitListener(any());
         verify(service, never()).addSessionDestroyListener(any());
         verify(service, never()).addSessionLockListener(any());
+    }
+
+    @Test
+    void registersUiInitListenerWhenUisEnabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service).addUIInitListener(any(UIInitListener.class));
+    }
+
+    @Test
+    void registersUiInitListenerWhenNavigationEnabledAndUisDisabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().uis(false).navigation(true)
+                        .build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service).addUIInitListener(any(UIInitListener.class));
+    }
+
+    @Test
+    void skipsUiInitListenerWhenUisAndNavigationDisabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().uis(false).navigation(false)
+                        .build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service, never()).addUIInitListener(any());
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.server.SessionLockListener;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinRequestInterceptor;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.communication.RpcInvocationListener;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -158,5 +159,46 @@ class MetricsServiceInitListenerTest {
         new MetricsServiceInitListener().serviceInit(event);
 
         verify(event, never()).addVaadinRequestInterceptor(any());
+    }
+
+    @Test
+    void registersRpcInvocationListenerWhenRequestsEnabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service)
+                .addRpcInvocationListener(any(RpcInvocationListener.class));
+    }
+
+    @Test
+    void skipsRpcInvocationListenerWhenRequestsDisabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().requests(false).build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service, never()).addRpcInvocationListener(any());
+    }
+
+    @Test
+    void skipsRpcInvocationListenerWhenOnlyErrorsEnabled() {
+        ObservabilityKit.install(new SimpleMeterRegistry(),
+                ObservabilitySettings.builder().requests(false).errors(true)
+                        .build());
+        VaadinService service = mock(VaadinService.class);
+        ServiceInitEvent event = mock(ServiceInitEvent.class);
+        when(event.getSource()).thenReturn(service);
+
+        new MetricsServiceInitListener().serviceInit(event);
+
+        verify(service, never()).addRpcInvocationListener(any());
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.SessionLockListener;
 import com.vaadin.flow.server.VaadinService;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -44,6 +45,7 @@ class MetricsServiceInitListenerTest {
         verify(service).addSessionInitListener(any(SessionInitListener.class));
         verify(service)
                 .addSessionDestroyListener(any(SessionDestroyListener.class));
+        verify(service).addSessionLockListener(any(SessionLockListener.class));
     }
 
     @Test
@@ -69,5 +71,6 @@ class MetricsServiceInitListenerTest {
 
         verify(service, never()).addSessionInitListener(any());
         verify(service, never()).addSessionDestroyListener(any());
+        verify(service, never()).addSessionLockListener(any());
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTracesTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/MetricsServiceInitListenerTracesTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.observability.micrometer.trace.TracingExecutor;
+
+class MetricsServiceInitListenerTracesTest {
+
+    @AfterEach
+    void tearDown() {
+        ObservabilityKit.reset();
+    }
+
+    @Test
+    void executorIsWrappedWhenTracesEnabled() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        MetricsServiceInitListener listener = new MetricsServiceInitListener(
+                new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().build());
+
+        VaadinService service = Mockito.mock(VaadinService.class);
+        ServiceInitEvent event = new ServiceInitEvent(service);
+        Executor original = Runnable::run;
+        event.setExecutor(original);
+
+        listener.serviceInit(event);
+
+        Optional<Executor> after = event.getExecutor();
+        Assertions.assertTrue(after.isPresent());
+        Assertions.assertInstanceOf(TracingExecutor.class, after.get(),
+                "executor should be wrapped in TracingExecutor");
+    }
+
+    @Test
+    void executorIsNotWrappedWhenTracesDisabled() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        MetricsServiceInitListener listener = new MetricsServiceInitListener(
+                new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().traces(false).build());
+
+        VaadinService service = Mockito.mock(VaadinService.class);
+        ServiceInitEvent event = new ServiceInitEvent(service);
+        Executor original = Runnable::run;
+        event.setExecutor(original);
+
+        listener.serviceInit(event);
+
+        Assertions.assertSame(original, event.getExecutor().orElse(null),
+                "executor should remain unwrapped");
+    }
+
+    @Test
+    void executorIsNotWrappedWhenObservationRegistryAbsent() {
+        MetricsServiceInitListener listener = new MetricsServiceInitListener(
+                new SimpleMeterRegistry(), null,
+                ObservabilitySettings.builder().build());
+
+        VaadinService service = Mockito.mock(VaadinService.class);
+        ServiceInitEvent event = new ServiceInitEvent(service);
+        Executor original = Runnable::run;
+        event.setExecutor(original);
+
+        listener.serviceInit(event);
+
+        Assertions.assertSame(original, event.getExecutor().orElse(null));
+    }
+
+    @Test
+    void noOpInstallHookCanBeOverriddenBySubclass() {
+        final boolean[] called = { false };
+        ObservationRegistry obs = ObservationRegistry.create();
+        new MetricsServiceInitListener(new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().build()) {
+            @Override
+            protected void installDefaultObservationHandlers(
+                    ObservationRegistry r, MeterRegistry mr) {
+                called[0] = true;
+            }
+        };
+        Assertions.assertTrue(called[0],
+                "subclass override should be dispatched from base ctor");
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilityKitTest.java
@@ -12,6 +12,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -32,6 +33,28 @@ class ObservabilityKitTest {
 
         assertSame(registry, ObservabilityKit.getMeterRegistry());
         assertSame(settings, ObservabilityKit.getSettings());
+        assertNotNull(ObservabilityKit.getObservationRegistry());
+    }
+
+    @Test
+    void install_tracesEnabled_createsObservationRegistry() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ObservabilitySettings settings = ObservabilitySettings.builder()
+                .traces(true).build();
+
+        ObservabilityKit.install(registry, settings);
+
+        assertNotNull(ObservabilityKit.getObservationRegistry());
+    }
+
+    @Test
+    void install_tracesDisabled_observationRegistryIsNull() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ObservabilitySettings settings = ObservabilitySettings.builder()
+                .traces(false).build();
+
+        ObservabilityKit.install(registry, settings);
+
         assertNull(ObservabilityKit.getObservationRegistry());
     }
 

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/ObservabilitySettingsTest.java
@@ -10,8 +10,10 @@ package com.vaadin.observability.micrometer;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ObservabilitySettingsTest {
@@ -31,6 +33,30 @@ class ObservabilitySettingsTest {
         assertFalse(settings.isTracesSessionId());
         assertEquals(200, settings.getRouteCardinalityLimit());
         assertEquals(100, settings.getClientRatePerSession());
+    }
+
+    @Test
+    void routeCardinalityLimit_zero_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ObservabilitySettings.builder().routeCardinalityLimit(0));
+    }
+
+    @Test
+    void routeCardinalityLimit_negative_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> ObservabilitySettings
+                .builder().routeCardinalityLimit(-5));
+    }
+
+    @Test
+    void clientRatePerSession_negative_throwsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ObservabilitySettings.builder().clientRatePerSession(-1));
+    }
+
+    @Test
+    void clientRatePerSession_zero_isAllowed() {
+        assertDoesNotThrow(
+                () -> ObservabilitySettings.builder().clientRatePerSession(0));
     }
 
     @Test

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RequestMetricsBinderObservationTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RequestMetricsBinderObservationTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.observability.micrometer.trace.ObservationNames;
+
+class RequestMetricsBinderObservationTest {
+
+    private static final class RecordingHandler
+            implements ObservationHandler<Observation.Context> {
+
+        final List<String> names = new ArrayList<>();
+        final List<String> contextualNames = new ArrayList<>();
+        final List<Map<String, String>> tags = new ArrayList<>();
+        final AtomicBoolean errored = new AtomicBoolean();
+
+        @Override
+        public void onStop(Observation.Context ctx) {
+            names.add(ctx.getName());
+            contextualNames.add(ctx.getContextualName());
+            Map<String, String> snap = new HashMap<>();
+            for (KeyValue kv : ctx.getLowCardinalityKeyValues()) {
+                snap.put(kv.getKey(), kv.getValue());
+            }
+            tags.add(snap);
+            if (ctx.getError() != null) {
+                errored.set(true);
+            }
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+    }
+
+    @Test
+    void observationProducesExpectedNameAndTagsOnSuccess() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        obs.observationConfig().observationHandler(recorder);
+
+        RequestMetricsBinder binder = new RequestMetricsBinder(
+                new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().build());
+
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        Mockito.when(req.getParameter("v-r")).thenReturn("uidl");
+        VaadinResponse resp = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        binder.requestStart(req, resp);
+        binder.requestEnd(req, resp, session);
+
+        Assertions.assertEquals(1, recorder.names.size());
+        Assertions.assertEquals(MeterNames.REQUEST_DURATION,
+                recorder.names.get(0));
+        // No poll/navigation marked, so a plain UIDL request is labelled as a
+        // generic "rpc" interaction rather than the opaque "uidl".
+        Assertions.assertEquals(
+                ObservationNames.REQUEST + "."
+                        + ObservationNames.INTERACTION_RPC,
+                recorder.contextualNames.get(0));
+        Assertions.assertEquals("uidl",
+                recorder.tags.get(0).get(ObservationNames.KEY_REQUEST_TYPE));
+        Assertions.assertEquals(ObservationNames.INTERACTION_RPC,
+                recorder.tags.get(0).get(ObservationNames.KEY_INTERACTION));
+        Assertions.assertEquals(ObservationNames.OUTCOME_SUCCESS,
+                recorder.tags.get(0).get(ObservationNames.KEY_OUTCOME));
+        Assertions.assertFalse(recorder.errored.get());
+    }
+
+    @Test
+    void pollMarkerLabelsRequestAsPoll() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        obs.observationConfig().observationHandler(recorder);
+
+        RequestMetricsBinder binder = new RequestMetricsBinder(
+                new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().build());
+
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        Mockito.when(req.getParameter("v-r")).thenReturn("uidl");
+        VaadinResponse resp = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        binder.requestStart(req, resp);
+        // Simulate a poll listener firing during request handling.
+        RequestInteraction.mark(ObservationNames.INTERACTION_POLL);
+        binder.requestEnd(req, resp, session);
+
+        Assertions.assertEquals(
+                ObservationNames.REQUEST + "."
+                        + ObservationNames.INTERACTION_POLL,
+                recorder.contextualNames.get(0));
+        Assertions.assertEquals(ObservationNames.INTERACTION_POLL,
+                recorder.tags.get(0).get(ObservationNames.KEY_INTERACTION));
+    }
+
+    @Test
+    void staleMarkerIsClearedAtRequestStart() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        obs.observationConfig().observationHandler(recorder);
+
+        RequestMetricsBinder binder = new RequestMetricsBinder(
+                new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().build());
+
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        Mockito.when(req.getParameter("v-r")).thenReturn("uidl");
+        VaadinResponse resp = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        // Leftover marker from a prior request on this thread.
+        RequestInteraction.mark(ObservationNames.INTERACTION_POLL);
+        binder.requestStart(req, resp);
+        binder.requestEnd(req, resp, session);
+
+        Assertions.assertEquals(ObservationNames.INTERACTION_RPC,
+                recorder.tags.get(0).get(ObservationNames.KEY_INTERACTION));
+    }
+
+    @Test
+    void observationCarriesErrorAndOutcomeOnException() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        obs.observationConfig().observationHandler(recorder);
+
+        RequestMetricsBinder binder = new RequestMetricsBinder(
+                new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().build());
+
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        VaadinResponse resp = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        binder.requestStart(req, resp);
+        binder.handleException(req, resp, session,
+                new IllegalStateException("boom"));
+        binder.requestEnd(req, resp, session);
+
+        Assertions.assertEquals(ObservationNames.OUTCOME_ERROR,
+                recorder.tags.get(0).get(ObservationNames.KEY_OUTCOME));
+        Assertions.assertTrue(recorder.errored.get());
+    }
+
+    @Test
+    void noObservationWhenTracesDisabled() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        obs.observationConfig().observationHandler(recorder);
+
+        RequestMetricsBinder binder = new RequestMetricsBinder(
+                new SimpleMeterRegistry(), obs,
+                ObservabilitySettings.builder().traces(false).build());
+
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        VaadinResponse resp = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        binder.requestStart(req, resp);
+        binder.requestEnd(req, resp, session);
+
+        Assertions.assertTrue(recorder.names.isEmpty(),
+                "no observation should fire when traces are disabled");
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RequestMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RequestMetricsBinderTest.java
@@ -40,6 +40,44 @@ class RequestMetricsBinderTest {
     }
 
     @Test
+    void errorStateDoesNotBleedIntoSubsequentRequest() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RequestMetricsBinder binder = new RequestMetricsBinder(registry,
+                ObservabilitySettings.builder().traces(false).build());
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        VaadinResponse res = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        // Request 1: ends with an error.
+        binder.requestStart(req, res);
+        binder.handleException(req, res, session,
+                new IllegalStateException("boom"));
+        binder.requestEnd(req, res, session);
+
+        Timer errorTimer = registry.find(MeterNames.REQUEST_DURATION)
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_ERROR).timer();
+        Assertions.assertNotNull(errorTimer, "request 1 should be error");
+        Assertions.assertEquals(1L, errorTimer.count());
+
+        // Request 2 on the same binder/thread: no exception.
+        binder.requestStart(req, res);
+        binder.requestEnd(req, res, session);
+
+        // The success timer must have exactly one sample (from request 2).
+        // Without F1 (clearing errored at requestStart), the errored flag left
+        // by request 1's handleException—when requestEnd is skipped—would bleed
+        // here. This test exercises the safe-guard by running both requests
+        // sequentially on the same binder instance.
+        Timer successTimer = registry.find(MeterNames.REQUEST_DURATION)
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS)
+                .timer();
+        Assertions.assertNotNull(successTimer,
+                "request 2 should record a success sample");
+        Assertions.assertEquals(1L, successTimer.count(),
+                "request 2 must be outcome=success, not bleed error from request 1");
+    }
+
+    @Test
     void exceptionRecordsErrorOutcomeAndExceptionCounter() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         RequestMetricsBinder binder = new RequestMetricsBinder(registry,

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RequestMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RequestMetricsBinderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+
+class RequestMetricsBinderTest {
+
+    @Test
+    void successfulRequestRecordsDurationWithSuccessOutcome() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RequestMetricsBinder binder = new RequestMetricsBinder(registry,
+                ObservabilitySettings.builder().traces(false).build());
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        VaadinResponse res = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        binder.requestStart(req, res);
+        binder.requestEnd(req, res, session);
+
+        Timer timer = registry.find(MeterNames.REQUEST_DURATION)
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS)
+                .timer();
+        Assertions.assertNotNull(timer);
+        Assertions.assertEquals(1L, timer.count());
+    }
+
+    @Test
+    void exceptionRecordsErrorOutcomeAndExceptionCounter() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RequestMetricsBinder binder = new RequestMetricsBinder(registry,
+                ObservabilitySettings.builder().traces(false).build());
+        VaadinRequest req = Mockito.mock(VaadinRequest.class);
+        VaadinResponse res = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+
+        binder.requestStart(req, res);
+        binder.handleException(req, res, session,
+                new IllegalStateException("boom"));
+        binder.requestEnd(req, res, session);
+
+        Timer timer = registry.find(MeterNames.REQUEST_DURATION)
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_ERROR).timer();
+        Assertions.assertNotNull(timer);
+        Assertions.assertEquals(1L, timer.count());
+
+        Assertions.assertEquals(1.0,
+                registry.find(MeterNames.ERRORS)
+                        .tag(MeterNames.TAG_EXCEPTION, "IllegalStateException")
+                        .counter().count(),
+                0.0);
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RouteTagResolverTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RouteTagResolverTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RouteTagResolverTest {
+
+    private static final class FakeRouteA extends Component {
+    }
+
+    private static final class FakeRouteB extends Component {
+    }
+
+    private static final class FakeRouteC extends Component {
+    }
+
+    @Test
+    public void nullTargetIsUnknown() {
+        RouteTagResolver resolver = new RouteTagResolver(10);
+        assertEquals(MeterNames.ROUTE_UNKNOWN, resolver.tagFor(null));
+    }
+
+    @Test
+    public void firstRoutesAreAdmittedThenBucketedAsOther() {
+        RouteTagResolver resolver = new RouteTagResolver(2);
+
+        String a = resolver.tagFor(FakeRouteA.class);
+        String b = resolver.tagFor(FakeRouteB.class);
+        String c = resolver.tagFor(FakeRouteC.class);
+
+        assertEquals(FakeRouteA.class.getSimpleName(), a);
+        assertEquals(FakeRouteB.class.getSimpleName(), b);
+        assertEquals(MeterNames.ROUTE_OTHER, c);
+    }
+
+    @Test
+    public void admittedRouteRemainsAdmittedAfterCapHit() {
+        RouteTagResolver resolver = new RouteTagResolver(1);
+        resolver.tagFor(FakeRouteA.class);
+        resolver.tagFor(FakeRouteB.class); // overflow -> _other
+
+        assertEquals(FakeRouteA.class.getSimpleName(),
+                resolver.tagFor(FakeRouteA.class));
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.communication.RpcInvocationEvent;
+import com.vaadin.observability.micrometer.trace.ObservationNames;
+
+class RpcMetricsBinderTest {
+
+    @Test
+    void directPathSuccessRecordsTimerWithTypeAndOutcome() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RpcMetricsBinder binder = new RpcMetricsBinder(registry, null,
+                ObservabilitySettings.builder().traces(false).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Timer timer = registry.find(MeterNames.RPC_DURATION)
+                .tag(MeterNames.TAG_TYPE, "event")
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS)
+                .timer();
+        Assertions.assertNotNull(timer,
+                "vaadin.rpc.duration timer with type=event, outcome=success should exist");
+        Assertions.assertEquals(1L, timer.count());
+    }
+
+    @Test
+    void directPathErrorRecordsTimerWithErrorOutcome() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RpcMetricsBinder binder = new RpcMetricsBinder(registry, null,
+                ObservabilitySettings.builder().traces(false).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+
+        binder.invocationStarted(event);
+        binder.invocationFailed(event, new RuntimeException("boom"));
+        binder.invocationEnded(event);
+
+        Timer timer = registry.find(MeterNames.RPC_DURATION)
+                .tag(MeterNames.TAG_TYPE, "event")
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_ERROR).timer();
+        Assertions.assertNotNull(timer,
+                "vaadin.rpc.duration timer with outcome=error should exist");
+        Assertions.assertEquals(1L, timer.count());
+    }
+
+    @Test
+    void invocationStartedMarksRequestInteractionAsRpc() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RpcMetricsBinder binder = new RpcMetricsBinder(registry, null,
+                ObservabilitySettings.builder().traces(false).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("publishedEventHandler");
+
+        binder.invocationStarted(event);
+
+        Assertions.assertEquals(ObservationNames.INTERACTION_RPC,
+                RequestInteraction.take(),
+                "invocationStarted should mark the request interaction as rpc");
+
+        // clean up
+        binder.invocationEnded(event);
+    }
+
+    @Test
+    void observationPathEmitsTimerWithTypeAndOutcomeTags() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry.observationConfig().observationHandler(
+                new DefaultMeterObservationHandler(registry));
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(registry,
+                observationRegistry, ObservabilitySettings.builder().build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Timer timer = registry.find(MeterNames.RPC_DURATION)
+                .tag(MeterNames.TAG_TYPE, "event")
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS)
+                .timer();
+        Assertions.assertNotNull(timer,
+                "DefaultMeterObservationHandler should emit vaadin.rpc.duration timer");
+        Assertions.assertEquals(1L, timer.count());
+    }
+
+    @Test
+    void errorStateDoesNotBleedIntoSubsequentInvocation() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RpcMetricsBinder binder = new RpcMetricsBinder(registry, null,
+                ObservabilitySettings.builder().traces(false).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+
+        // First invocation: error
+        binder.invocationStarted(event);
+        binder.invocationFailed(event, new RuntimeException("boom"));
+        binder.invocationEnded(event);
+
+        // Second invocation on the same binder instance/thread: no error
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Timer successTimer = registry.find(MeterNames.RPC_DURATION)
+                .tag(MeterNames.TAG_TYPE, "event")
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS)
+                .timer();
+        Assertions.assertNotNull(successTimer,
+                "second invocation should record success outcome");
+        Assertions.assertEquals(1L, successTimer.count(),
+                "error state must not bleed into next invocation");
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
@@ -8,9 +8,18 @@
  */
 package com.vaadin.observability.micrometer;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.micrometer.common.KeyValue;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -20,6 +29,34 @@ import com.vaadin.flow.server.communication.RpcInvocationEvent;
 import com.vaadin.observability.micrometer.trace.ObservationNames;
 
 class RpcMetricsBinderTest {
+
+    private static final class RecordingHandler
+            implements ObservationHandler<Observation.Context> {
+
+        final List<String> names = new ArrayList<>();
+        final List<Map<String, String>> tags = new ArrayList<>();
+        final AtomicBoolean errored = new AtomicBoolean();
+        Observation.Context lastContext;
+
+        @Override
+        public void onStop(Observation.Context ctx) {
+            lastContext = ctx;
+            names.add(ctx.getName());
+            Map<String, String> snap = new HashMap<>();
+            for (KeyValue kv : ctx.getLowCardinalityKeyValues()) {
+                snap.put(kv.getKey(), kv.getValue());
+            }
+            tags.add(snap);
+            if (ctx.getError() != null) {
+                errored.set(true);
+            }
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+    }
 
     @Test
     void directPathSuccessRecordsTimerWithTypeAndOutcome() {
@@ -104,6 +141,69 @@ class RpcMetricsBinderTest {
                 .timer();
         Assertions.assertNotNull(timer,
                 "DefaultMeterObservationHandler should emit vaadin.rpc.duration timer");
+        Assertions.assertEquals(1L, timer.count());
+    }
+
+    @Test
+    void observationPathErrorSetsOutcomeAndRecordsError() {
+        SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        observationRegistry.observationConfig()
+                .observationHandler(
+                        new DefaultMeterObservationHandler(simpleRegistry))
+                .observationHandler(recorder);
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(simpleRegistry,
+                observationRegistry,
+                ObservabilitySettings.builder().traces(true).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+
+        binder.invocationStarted(event);
+        binder.invocationFailed(event, new RuntimeException("boom"));
+        binder.invocationEnded(event);
+
+        Timer timer = simpleRegistry.find(MeterNames.RPC_DURATION)
+                .tag(MeterNames.TAG_TYPE, "event")
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_ERROR).timer();
+        Assertions.assertNotNull(timer,
+                "vaadin.rpc.duration timer with outcome=error should exist");
+        Assertions.assertEquals(1L, timer.count());
+        Assertions.assertNotNull(recorder.lastContext,
+                "recording handler should have been called");
+        Assertions.assertNotNull(recorder.lastContext.getError(),
+                "observation context should carry the recorded error");
+        Assertions.assertTrue(recorder.errored.get(),
+                "errored flag should be set by the recording handler");
+    }
+
+    @Test
+    void noObservationWhenTracesDisabled() {
+        SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        observationRegistry.observationConfig().observationHandler(recorder);
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(simpleRegistry,
+                observationRegistry,
+                ObservabilitySettings.builder().traces(false).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Assertions.assertTrue(recorder.names.isEmpty(),
+                "no observation should fire when traces are disabled");
+        Timer timer = simpleRegistry.find(MeterNames.RPC_DURATION)
+                .tag(MeterNames.TAG_TYPE, "event")
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS)
+                .timer();
+        Assertions.assertNotNull(timer,
+                "direct-path timer should be recorded even when traces are disabled");
         Assertions.assertEquals(1L, timer.count());
     }
 

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionLockMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionLockMetricsBinderTest.java
@@ -9,9 +9,12 @@
 package com.vaadin.observability.micrometer;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.SessionLockEvent;
+import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,8 +23,13 @@ import static org.mockito.Mockito.mock;
 
 class SessionLockMetricsBinderTest {
 
+    @AfterEach
+    void clearCurrentInstance() {
+        CurrentInstance.clearAll();
+    }
+
     @Test
-    void acquireRecordsWaitTimer() {
+    void acquireRecordsWaitTimerWithAccessContext() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         SessionLockMetricsBinder binder = new SessionLockMetricsBinder(
                 registry);
@@ -32,11 +40,13 @@ class SessionLockMetricsBinderTest {
         binder.lockAcquired(event);
 
         assertEquals(1L,
-                registry.find(MeterNames.SESSION_LOCK_WAIT).timer().count());
+                registry.get(MeterNames.SESSION_LOCK_WAIT)
+                        .tag(MeterNames.TAG_CONTEXT, MeterNames.CONTEXT_ACCESS)
+                        .timer().count());
     }
 
     @Test
-    void releaseRecordsHoldTimer() {
+    void releaseRecordsHoldTimerWithAccessContext() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         SessionLockMetricsBinder binder = new SessionLockMetricsBinder(
                 registry);
@@ -48,7 +58,34 @@ class SessionLockMetricsBinderTest {
         binder.lockReleased(event);
 
         assertEquals(1L,
-                registry.find(MeterNames.SESSION_LOCK_HOLD).timer().count());
+                registry.get(MeterNames.SESSION_LOCK_HOLD)
+                        .tag(MeterNames.TAG_CONTEXT, MeterNames.CONTEXT_ACCESS)
+                        .timer().count());
+    }
+
+    @Test
+    void acquireAndReleaseRecordTimersWithRequestContext() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionLockMetricsBinder binder = new SessionLockMetricsBinder(
+                registry);
+        SessionLockEvent event = new SessionLockEvent(
+                mock(VaadinService.class));
+
+        CurrentInstance.set(VaadinRequest.class, mock(VaadinRequest.class));
+        try {
+            binder.lockRequested(event);
+            binder.lockAcquired(event);
+            binder.lockReleased(event);
+
+            assertEquals(1L, registry.get(MeterNames.SESSION_LOCK_WAIT)
+                    .tag(MeterNames.TAG_CONTEXT, MeterNames.CONTEXT_REQUEST)
+                    .timer().count());
+            assertEquals(1L, registry.get(MeterNames.SESSION_LOCK_HOLD)
+                    .tag(MeterNames.TAG_CONTEXT, MeterNames.CONTEXT_REQUEST)
+                    .timer().count());
+        } finally {
+            CurrentInstance.clearAll();
+        }
     }
 
     @Test

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionLockMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionLockMetricsBinderTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.server.SessionLockEvent;
+import com.vaadin.flow.server.VaadinService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+class SessionLockMetricsBinderTest {
+
+    @Test
+    void acquireRecordsWaitTimer() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionLockMetricsBinder binder = new SessionLockMetricsBinder(
+                registry);
+        SessionLockEvent event = new SessionLockEvent(
+                mock(VaadinService.class));
+
+        binder.lockRequested(event);
+        binder.lockAcquired(event);
+
+        assertEquals(1L,
+                registry.find(MeterNames.SESSION_LOCK_WAIT).timer().count());
+    }
+
+    @Test
+    void releaseRecordsHoldTimer() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionLockMetricsBinder binder = new SessionLockMetricsBinder(
+                registry);
+        SessionLockEvent event = new SessionLockEvent(
+                mock(VaadinService.class));
+
+        binder.lockRequested(event);
+        binder.lockAcquired(event);
+        binder.lockReleased(event);
+
+        assertEquals(1L,
+                registry.find(MeterNames.SESSION_LOCK_HOLD).timer().count());
+    }
+
+    @Test
+    void releaseWithoutAcquireDoesNotRecordHold() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionLockMetricsBinder binder = new SessionLockMetricsBinder(
+                registry);
+        SessionLockEvent event = new SessionLockEvent(
+                mock(VaadinService.class));
+
+        binder.lockReleased(event);
+
+        assertNull(registry.find(MeterNames.SESSION_LOCK_HOLD).timer());
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/SessionMetricsBinderTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.server.SessionDestroyEvent;
 import com.vaadin.flow.server.SessionInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -23,17 +25,68 @@ class SessionMetricsBinderTest {
     void gaugeTracksActiveSessionCount() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         SessionMetricsBinder binder = new SessionMetricsBinder(registry);
+        VaadinService service = mock(VaadinService.class);
+        VaadinSession session1 = mock(VaadinSession.class);
+        VaadinSession session2 = mock(VaadinSession.class);
 
         assertEquals(0.0,
                 registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value());
 
-        binder.sessionInit(mock(SessionInitEvent.class));
-        binder.sessionInit(mock(SessionInitEvent.class));
+        binder.sessionInit(new SessionInitEvent(service, session1, null));
+        binder.sessionInit(new SessionInitEvent(service, session2, null));
         assertEquals(2.0,
                 registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value());
 
-        binder.sessionDestroy(mock(SessionDestroyEvent.class));
+        binder.sessionDestroy(new SessionDestroyEvent(service, session1));
         assertEquals(1.0,
                 registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value());
+    }
+
+    @Test
+    void initIncrementsCreatedCounterAndActiveGauge() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionMetricsBinder binder = new SessionMetricsBinder(registry);
+        VaadinService service = mock(VaadinService.class);
+        VaadinSession session = mock(VaadinSession.class);
+        SessionInitEvent event = new SessionInitEvent(service, session, null);
+
+        binder.sessionInit(event);
+
+        assertEquals(1.0,
+                registry.get(MeterNames.SESSIONS_CREATED).counter().count(),
+                0.0);
+        assertEquals(1.0,
+                registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value(), 0.0);
+    }
+
+    @Test
+    void destroyDecrementsActiveAndRecordsDuration() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionMetricsBinder binder = new SessionMetricsBinder(registry);
+        VaadinService service = mock(VaadinService.class);
+        VaadinSession session = mock(VaadinSession.class);
+
+        binder.sessionInit(new SessionInitEvent(service, session, null));
+        binder.sessionDestroy(new SessionDestroyEvent(service, session));
+
+        assertEquals(0.0,
+                registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value(), 0.0);
+        assertEquals(1L,
+                registry.get(MeterNames.SESSIONS_DURATION).timer().count());
+    }
+
+    @Test
+    void destroyWithoutInitOnlyDecrementsAndDoesNotRecordDuration() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SessionMetricsBinder binder = new SessionMetricsBinder(registry);
+        VaadinService service = mock(VaadinService.class);
+        VaadinSession session = mock(VaadinSession.class);
+
+        binder.sessionDestroy(new SessionDestroyEvent(service, session));
+
+        assertEquals(-1.0,
+                registry.get(MeterNames.SESSIONS_ACTIVE).gauge().value(), 0.0);
+        assertEquals(0L,
+                registry.get(MeterNames.SESSIONS_DURATION).timer().count());
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/UiLifecycleTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/UiLifecycleTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.UIInitEvent;
+import com.vaadin.flow.server.VaadinService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies that {@link UiMetricsBinder} correctly tracks UI lifecycle via the
+ * {@code vaadin.ui.created} counter and {@code vaadin.ui.active} gauge.
+ */
+class UiLifecycleTest {
+
+    private SimpleMeterRegistry registry;
+    private UiMetricsBinder binder;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        binder = new UiMetricsBinder(registry, null,
+                ObservabilitySettings.builder().build());
+    }
+
+    @Test
+    void uiInitIncrementsCreatedCounterAndActiveGauge() {
+        UI ui = mock(UI.class);
+        VaadinService service = mock(VaadinService.class);
+        UIInitEvent event = new UIInitEvent(ui, service);
+
+        binder.uiInit(event);
+
+        assertEquals(1.0, registry.counter(MeterNames.UI_CREATED).count(), 0.0);
+        assertEquals(1.0, registry.find(MeterNames.UI_ACTIVE).gauge().value(),
+                0.0);
+    }
+
+    @Test
+    void multipleUiInitsAccumulate() {
+        VaadinService service = mock(VaadinService.class);
+        for (int i = 0; i < 3; i++) {
+            binder.uiInit(new UIInitEvent(mock(UI.class), service));
+        }
+
+        assertEquals(3.0, registry.counter(MeterNames.UI_CREATED).count(), 0.0);
+        assertEquals(3.0, registry.find(MeterNames.UI_ACTIVE).gauge().value(),
+                0.0);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void detachDecrementsActiveGauge() {
+        UI ui = mock(UI.class);
+        VaadinService service = mock(VaadinService.class);
+        UIInitEvent event = new UIInitEvent(ui, service);
+
+        binder.uiInit(event);
+        assertEquals(1.0, registry.find(MeterNames.UI_ACTIVE).gauge().value(),
+                0.0);
+
+        // Capture and invoke the detach listener to simulate UI detach
+        ArgumentCaptor<ComponentEventListener<DetachEvent>> captor = ArgumentCaptor
+                .forClass(ComponentEventListener.class);
+        verify(ui).addDetachListener(captor.capture());
+        captor.getValue().onComponentEvent(mock(DetachEvent.class));
+
+        assertEquals(0.0, registry.find(MeterNames.UI_ACTIVE).gauge().value(),
+                0.0);
+    }
+
+    @Test
+    void doesNotTrackUisWhenUisDisabled() {
+        binder = new UiMetricsBinder(registry, null, ObservabilitySettings
+                .builder().uis(false).navigation(false).build());
+        UI ui = mock(UI.class);
+        VaadinService service = mock(VaadinService.class);
+
+        binder.uiInit(new UIInitEvent(ui, service));
+
+        assertEquals(0.0, registry.counter(MeterNames.UI_CREATED).count(), 0.0);
+        // gauge is pre-registered at construction and stays at 0
+        assertEquals(0.0, registry.find(MeterNames.UI_ACTIVE).gauge().value(),
+                0.0);
+    }
+
+    @Test
+    void registersNavigationBinderWhenNavigationEnabled() {
+        // binder is created with navigation=true (default)
+        UI ui = mock(UI.class);
+        VaadinService service = mock(VaadinService.class);
+
+        binder.uiInit(new UIInitEvent(ui, service));
+
+        verify(ui).addBeforeEnterListener(any());
+        verify(ui).addAfterNavigationListener(any());
+    }
+
+    @Test
+    void skipsNavigationBinderWhenNavigationDisabled() {
+        binder = new UiMetricsBinder(registry, null,
+                ObservabilitySettings.builder().navigation(false).build());
+        UI ui = mock(UI.class);
+        VaadinService service = mock(VaadinService.class);
+
+        binder.uiInit(new UIInitEvent(ui, service));
+
+        verify(ui, org.mockito.Mockito.never()).addBeforeEnterListener(any());
+        verify(ui, org.mockito.Mockito.never())
+                .addAfterNavigationListener(any());
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/UiLifecycleTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/UiLifecycleTest.java
@@ -14,15 +14,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.UIInitEvent;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.observability.micrometer.client.MetricsCollectorElement;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -148,5 +151,29 @@ class UiLifecycleTest {
         UI ui = mock(UI.class);
         b.uiInit(new UIInitEvent(ui, mock(VaadinService.class)));
         verify(ui, org.mockito.Mockito.never()).addPollListener(any());
+    }
+
+    @Test
+    void uiInitAddsMetricsCollectorElementWhenClientEnabled() {
+        // client is enabled by default
+        UI ui = mock(UI.class);
+        binder.uiInit(new UIInitEvent(ui, mock(VaadinService.class)));
+
+        ArgumentCaptor<Component[]> captor = ArgumentCaptor
+                .forClass(Component[].class);
+        verify(ui).add(captor.capture());
+        Component[] added = captor.getValue();
+        assertEquals(1, added.length);
+        assertEquals(MetricsCollectorElement.class, added[0].getClass());
+    }
+
+    @Test
+    void uiInitDoesNotAddMetricsCollectorElementWhenClientDisabled() {
+        UiMetricsBinder b = new UiMetricsBinder(new SimpleMeterRegistry(), null,
+                ObservabilitySettings.builder().client(false).build());
+        UI ui = mock(UI.class);
+        b.uiInit(new UIInitEvent(ui, mock(VaadinService.class)));
+
+        verify(ui, never()).add(any(Component[].class));
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/UiLifecycleTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/UiLifecycleTest.java
@@ -9,6 +9,7 @@
 package com.vaadin.observability.micrometer;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -88,17 +89,20 @@ class UiLifecycleTest {
 
     @Test
     void doesNotTrackUisWhenUisDisabled() {
-        binder = new UiMetricsBinder(registry, null, ObservabilitySettings
-                .builder().uis(false).navigation(false).build());
+        SimpleMeterRegistry freshRegistry = new SimpleMeterRegistry();
+        UiMetricsBinder disabledBinder = new UiMetricsBinder(freshRegistry,
+                null, ObservabilitySettings.builder().uis(false)
+                        .navigation(false).build());
         UI ui = mock(UI.class);
         VaadinService service = mock(VaadinService.class);
 
-        binder.uiInit(new UIInitEvent(ui, service));
+        disabledBinder.uiInit(new UIInitEvent(ui, service));
 
-        assertEquals(0.0, registry.counter(MeterNames.UI_CREATED).count(), 0.0);
-        // gauge is pre-registered at construction and stays at 0
-        assertEquals(0.0, registry.find(MeterNames.UI_ACTIVE).gauge().value(),
+        assertEquals(0.0, freshRegistry.counter(MeterNames.UI_CREATED).count(),
                 0.0);
+        // gauge is pre-registered at construction and stays at 0
+        assertEquals(0.0,
+                freshRegistry.find(MeterNames.UI_ACTIVE).gauge().value(), 0.0);
     }
 
     @Test
@@ -125,5 +129,24 @@ class UiLifecycleTest {
         verify(ui, org.mockito.Mockito.never()).addBeforeEnterListener(any());
         verify(ui, org.mockito.Mockito.never())
                 .addAfterNavigationListener(any());
+    }
+
+    @Test
+    void registersPollListenerWhenTracesEnabled() {
+        ObservationRegistry or = ObservationRegistry.create();
+        UiMetricsBinder b = new UiMetricsBinder(new SimpleMeterRegistry(), or,
+                ObservabilitySettings.builder().traces(true).build());
+        UI ui = mock(UI.class);
+        b.uiInit(new UIInitEvent(ui, mock(VaadinService.class)));
+        verify(ui).addPollListener(any());
+    }
+
+    @Test
+    void skipsPollListenerWhenTracesDisabled() {
+        UiMetricsBinder b = new UiMetricsBinder(new SimpleMeterRegistry(), null,
+                ObservabilitySettings.builder().traces(false).build());
+        UI ui = mock(UI.class);
+        b.uiInit(new UIInitEvent(ui, mock(VaadinService.class)));
+        verify(ui, org.mockito.Mockito.never()).addPollListener(any());
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientMetricNamesTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientMetricNamesTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.observability.micrometer.MeterNames;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ClientMetricNames}.
+ */
+class ClientMetricNamesTest {
+
+    @Test
+    void bootstrapDurationIsAllowed() {
+        assertTrue(ClientMetricNames
+                .isAllowed(MeterNames.CLIENT_BOOTSTRAP_DURATION));
+    }
+
+    @Test
+    void navigationDurationIsAllowed() {
+        assertTrue(ClientMetricNames
+                .isAllowed(MeterNames.CLIENT_NAVIGATION_DURATION));
+    }
+
+    @Test
+    void webVitalsLcpIsAllowed() {
+        assertTrue(
+                ClientMetricNames.isAllowed(MeterNames.CLIENT_WEB_VITALS_LCP));
+    }
+
+    @Test
+    void webVitalsFcpIsAllowed() {
+        assertTrue(
+                ClientMetricNames.isAllowed(MeterNames.CLIENT_WEB_VITALS_FCP));
+    }
+
+    @Test
+    void clientErrorsIsAllowed() {
+        assertTrue(ClientMetricNames.isAllowed(MeterNames.CLIENT_ERRORS));
+    }
+
+    @Test
+    void clientRpcDurationIsNotAllowed() {
+        // Deliberate reduction: RPC is measured server-side; client RPC timing
+        // removed.
+        assertFalse(
+                ClientMetricNames.isAllowed(MeterNames.CLIENT_RPC_DURATION));
+    }
+
+    @Test
+    void unknownNameIsNotAllowed() {
+        assertFalse(
+                ClientMetricNames.isAllowed("vaadin.client.unknown.metric"));
+    }
+
+    @Test
+    void nullNameIsNotAllowed() {
+        assertFalse(ClientMetricNames.isAllowed(null));
+    }
+
+    @Test
+    void clientErrorsIsCounter() {
+        assertTrue(ClientMetricNames.isCounter(MeterNames.CLIENT_ERRORS));
+    }
+
+    @Test
+    void bootstrapDurationIsNotCounter() {
+        assertFalse(ClientMetricNames
+                .isCounter(MeterNames.CLIENT_BOOTSTRAP_DURATION));
+    }
+
+    @Test
+    void navigationDurationIsNotCounter() {
+        assertFalse(ClientMetricNames
+                .isCounter(MeterNames.CLIENT_NAVIGATION_DURATION));
+    }
+
+    @Test
+    void lcpIsNotCounter() {
+        assertFalse(
+                ClientMetricNames.isCounter(MeterNames.CLIENT_WEB_VITALS_LCP));
+    }
+
+    @Test
+    void fcpIsNotCounter() {
+        assertFalse(
+                ClientMetricNames.isCounter(MeterNames.CLIENT_WEB_VITALS_FCP));
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientMetricsBinderTest.java
@@ -103,7 +103,7 @@ class ClientMetricsBinderTest {
                 1e-9);
     }
 
-    // --- ingest: disallowed name drops and increments dropped counter ---
+    // --- ingest: disallowed name is silently skipped ---
 
     @Test
     void ingestDisallowedNameIsDropped() {
@@ -177,8 +177,7 @@ class ClientMetricsBinderTest {
     void recordThrottledZeroDoesNotRegisterCounter() {
         binder.recordThrottled(0);
 
-        // Counter should not be pre-registered (find returns null when not
-        // registered in SimpleMeterRegistry without prior access)
+        // recordThrottled(0) must not increment the counter
         assertEquals(0.0, registry.counter(MeterNames.CLIENT_THROTTLED).count(),
                 1e-9);
     }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientMetricsBinderTest.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+import java.util.List;
+import java.util.Map;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.observability.micrometer.MeterNames;
+import com.vaadin.observability.micrometer.ObservabilitySettings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link ClientMetricsBinder}.
+ */
+class ClientMetricsBinderTest {
+
+    private SimpleMeterRegistry registry;
+    private ClientMetricsBinder binder;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        binder = new ClientMetricsBinder(registry,
+                ObservabilitySettings.builder().build());
+    }
+
+    // --- ingest: timer ---
+
+    @Test
+    void ingestBootstrapSampleRecordsTimer() {
+        ClientSample sample = sample(MeterNames.CLIENT_BOOTSTRAP_DURATION,
+                250.0, Map.of());
+        binder.ingest(List.of(sample));
+
+        assertEquals(1L,
+                registry.timer(MeterNames.CLIENT_BOOTSTRAP_DURATION).count());
+    }
+
+    @Test
+    void ingestNavigationSampleRecordsTimer() {
+        ClientSample sample = sample(MeterNames.CLIENT_NAVIGATION_DURATION,
+                100.0, Map.of("route", "/home", "trigger", "programmatic"));
+        binder.ingest(List.of(sample));
+
+        assertEquals(1L, registry.timer(MeterNames.CLIENT_NAVIGATION_DURATION,
+                "route", "_unknown", "trigger", "programmatic").count());
+    }
+
+    @Test
+    void ingestLcpSampleRecordsTimer() {
+        ClientSample sample = sample(MeterNames.CLIENT_WEB_VITALS_LCP, 1200.0,
+                Map.of());
+        binder.ingest(List.of(sample));
+
+        assertEquals(1L,
+                registry.timer(MeterNames.CLIENT_WEB_VITALS_LCP).count());
+    }
+
+    @Test
+    void ingestFcpSampleRecordsTimer() {
+        ClientSample sample = sample(MeterNames.CLIENT_WEB_VITALS_FCP, 800.0,
+                Map.of());
+        binder.ingest(List.of(sample));
+
+        assertEquals(1L,
+                registry.timer(MeterNames.CLIENT_WEB_VITALS_FCP).count());
+    }
+
+    // --- ingest: counter ---
+
+    @Test
+    void ingestErrorSampleIncrementsCounter() {
+        ClientSample sample = sample(MeterNames.CLIENT_ERRORS, 0.0,
+                Map.of("kind", "uncaught"));
+        binder.ingest(List.of(sample));
+
+        assertEquals(1.0, registry
+                .counter(MeterNames.CLIENT_ERRORS, "kind", "uncaught").count(),
+                1e-9);
+    }
+
+    @Test
+    void ingestMultipleErrorsAccumulates() {
+        binder.ingest(List.of(
+                sample(MeterNames.CLIENT_ERRORS, 0.0,
+                        Map.of("kind", "promise")),
+                sample(MeterNames.CLIENT_ERRORS, 0.0,
+                        Map.of("kind", "promise"))));
+
+        assertEquals(2.0, registry
+                .counter(MeterNames.CLIENT_ERRORS, "kind", "promise").count(),
+                1e-9);
+    }
+
+    // --- ingest: disallowed name drops and increments dropped counter ---
+
+    @Test
+    void ingestDisallowedNameIsDropped() {
+        ClientSample sample = sample("vaadin.client.rpc.duration", 50.0,
+                Map.of());
+        binder.ingest(List.of(sample));
+
+        // The disallowed sample is NOT recorded as a timer
+        assertEquals(0L, registry.find("vaadin.client.rpc.duration").timers()
+                .stream().mapToLong(t -> t.count()).sum());
+        // No dropped counter incremented here (dropped is only for
+        // unrecognized *incoming* names; recordDropped is a separate method)
+        assertEquals(0.0, registry.counter(MeterNames.CLIENT_DROPPED).count(),
+                1e-9);
+    }
+
+    @Test
+    void ingestNullListDoesNotThrow() {
+        binder.ingest(null); // must not throw
+    }
+
+    @Test
+    void ingestSampleWithNegativeValueIsSkipped() {
+        ClientSample sample = sample(MeterNames.CLIENT_BOOTSTRAP_DURATION, -1.0,
+                Map.of());
+        binder.ingest(List.of(sample));
+
+        assertEquals(0L,
+                registry.timer(MeterNames.CLIENT_BOOTSTRAP_DURATION).count());
+    }
+
+    // --- tag capping ---
+
+    @Test
+    void tagValueOverCapBecomesOther() {
+        // tag value longer than 200 chars should be capped
+        String longValue = "x".repeat(201);
+        ClientSample sample = sample(MeterNames.CLIENT_BOOTSTRAP_DURATION,
+                100.0, Map.of("custom", longValue));
+        binder.ingest(List.of(sample));
+
+        // Timer is recorded with "_other" for the capped value
+        assertEquals(1L, registry.timer(MeterNames.CLIENT_BOOTSTRAP_DURATION,
+                "custom", MeterNames.ROUTE_OTHER).count());
+    }
+
+    @Test
+    void tagKeyOverCapIsDropped() {
+        // tag key longer than 64 chars should be dropped (tag not added)
+        String longKey = "k".repeat(65);
+        ClientSample sample = sample(MeterNames.CLIENT_BOOTSTRAP_DURATION,
+                100.0, Map.of(longKey, "value"));
+        binder.ingest(List.of(sample));
+
+        // Timer recorded without that tag
+        assertEquals(1L,
+                registry.timer(MeterNames.CLIENT_BOOTSTRAP_DURATION).count());
+    }
+
+    // --- recordThrottled ---
+
+    @Test
+    void recordThrottledIncrementsCounter() {
+        binder.recordThrottled(3);
+
+        assertEquals(3.0, registry.counter(MeterNames.CLIENT_THROTTLED).count(),
+                1e-9);
+    }
+
+    @Test
+    void recordThrottledZeroDoesNotRegisterCounter() {
+        binder.recordThrottled(0);
+
+        // Counter should not be pre-registered (find returns null when not
+        // registered in SimpleMeterRegistry without prior access)
+        assertEquals(0.0, registry.counter(MeterNames.CLIENT_THROTTLED).count(),
+                1e-9);
+    }
+
+    // --- recordDropped ---
+
+    @Test
+    void recordDroppedIncrementsCounter() {
+        binder.recordDropped(2);
+
+        assertEquals(2.0, registry.counter(MeterNames.CLIENT_DROPPED).count(),
+                1e-9);
+    }
+
+    // --- helper ---
+
+    private static ClientSample sample(String name, double valueMs,
+            Map<String, String> tags) {
+        ClientSample s = new ClientSample();
+        s.setName(name);
+        s.setValueMs(valueMs);
+        s.setTags(tags);
+        return s;
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientRateLimiterTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/client/ClientRateLimiterTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link ClientRateLimiter}.
+ */
+class ClientRateLimiterTest {
+
+    @Test
+    void grantsUpToRateWithinWindow() {
+        ClientRateLimiter limiter = new ClientRateLimiter(5);
+        assertEquals(5, limiter.tryAcquire(5));
+    }
+
+    @Test
+    void partialGrantWhenBudgetExhausted() {
+        ClientRateLimiter limiter = new ClientRateLimiter(3);
+        // Consume all 3 tokens
+        assertEquals(3, limiter.tryAcquire(3));
+        // No more budget in this window
+        assertEquals(0, limiter.tryAcquire(2));
+    }
+
+    @Test
+    void partialGrantStopsAtRemaining() {
+        ClientRateLimiter limiter = new ClientRateLimiter(4);
+        // Consume 2 tokens first
+        assertEquals(2, limiter.tryAcquire(2));
+        // Only 2 remaining; requesting 5 should grant 2
+        assertEquals(2, limiter.tryAcquire(5));
+    }
+
+    @Test
+    void zeroRateGrantsUnlimited() {
+        // ratePerWindow <= 0 means unlimited
+        ClientRateLimiter limiter = new ClientRateLimiter(0);
+        assertEquals(100, limiter.tryAcquire(100));
+        assertEquals(1000, limiter.tryAcquire(1000));
+    }
+
+    @Test
+    void negativeRateGrantsUnlimited() {
+        ClientRateLimiter limiter = new ClientRateLimiter(-1);
+        assertEquals(50, limiter.tryAcquire(50));
+    }
+
+    @Test
+    void requestMoreThanRateGrantsRate() {
+        ClientRateLimiter limiter = new ClientRateLimiter(10);
+        // Request more than the window budget allows
+        assertEquals(10, limiter.tryAcquire(20));
+    }
+
+    @Test
+    void singleTokenGranted() {
+        ClientRateLimiter limiter = new ClientRateLimiter(1);
+        assertEquals(1, limiter.tryAcquire(1));
+        // Second call in same window: budget exhausted
+        assertEquals(0, limiter.tryAcquire(1));
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/trace/TracingExecutorObservationTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/trace/TracingExecutorObservationTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.trace;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TracingExecutorObservationTest {
+
+    private static final class NameRecorder
+            implements ObservationHandler<Observation.Context> {
+
+        final List<String> names = new ArrayList<>();
+        final List<String> contextualNames = new ArrayList<>();
+        final AtomicBoolean errored = new AtomicBoolean();
+
+        @Override
+        public void onStop(Observation.Context ctx) {
+            names.add(ctx.getName());
+            contextualNames.add(ctx.getContextualName());
+            if (ctx.getError() != null) {
+                errored.set(true);
+            }
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+    }
+
+    @Test
+    void everyTaskEmitsUiAccessObservation() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        NameRecorder recorder = new NameRecorder();
+        obs.observationConfig().observationHandler(recorder);
+
+        Executor inline = Runnable::run;
+        TracingExecutor te = new TracingExecutor(inline, obs);
+
+        te.execute(() -> {
+        });
+        te.execute(() -> {
+        });
+
+        Assertions.assertEquals(2, recorder.names.size());
+        Assertions.assertEquals(ObservationNames.UI_ACCESS,
+                recorder.names.get(0));
+        Assertions.assertEquals(ObservationNames.UI_ACCESS,
+                recorder.contextualNames.get(0));
+    }
+
+    @Test
+    void exceptionsArePropagatedAndRecordedOnObservation() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        NameRecorder recorder = new NameRecorder();
+        obs.observationConfig().observationHandler(recorder);
+
+        TracingExecutor te = new TracingExecutor(Runnable::run, obs);
+
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> te.execute(() -> {
+                    throw new IllegalStateException("boom");
+                }));
+        Assertions.assertTrue(recorder.errored.get());
+    }
+
+    @Test
+    void noObservationWhenRegistryAbsent() {
+        ObservationRegistry obs = ObservationRegistry.create();
+        NameRecorder recorder = new NameRecorder();
+        obs.observationConfig().observationHandler(recorder);
+
+        TracingExecutor te = new TracingExecutor(Runnable::run);
+        AtomicBoolean ran = new AtomicBoolean();
+
+        te.execute(() -> ran.set(true));
+
+        Assertions.assertTrue(ran.get());
+        Assertions.assertTrue(recorder.names.isEmpty(),
+                "no observation should be emitted when registry is null");
+    }
+}

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/trace/TracingExecutorTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/trace/TracingExecutorTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2000-2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.micrometer.trace;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TracingExecutorTest {
+
+    @Test
+    void delegatesToWrappedExecutor() {
+        AtomicBoolean ran = new AtomicBoolean();
+        Executor inline = Runnable::run;
+        new TracingExecutor(inline).execute(() -> ran.set(true));
+        Assertions.assertTrue(ran.get(), "wrapped runnable should have run");
+    }
+
+    @Test
+    void capturesAndForwardsCommandToDelegate() {
+        AtomicReference<Runnable> captured = new AtomicReference<>();
+        Executor capturing = captured::set;
+
+        Runnable original = () -> {
+        };
+        new TracingExecutor(capturing).execute(original);
+
+        // The delegate should have received SOMETHING (the snapshot-wrapped
+        // command), not necessarily the original instance: a context-aware
+        // wrapper is expected.
+        Assertions.assertNotNull(captured.get());
+    }
+
+    @Test
+    void rejectsNullDelegate() {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new TracingExecutor(null));
+    }
+}


### PR DESCRIPTION
Closes #326.

Completes the framework-agnostic core (`observability-kit-micrometer`) with the full instrumentation set, wired behind `ObservabilitySettings` toggles via the SPI `MetricsServiceInitListener`.

## What's included
- **Sessions** — `vaadin.sessions.{active,created,duration}`; **session-lock** contention `vaadin.session.lock.{wait,hold}` (tag `context`) via `SessionLockListener` (vaadin/flow#24498).
- **UI** — `vaadin.ui.{active,created}`.
- **Navigation** — `vaadin.navigation` (tags `route`, `outcome`) with a route-cardinality cap.
- **Requests/errors** — `vaadin.request.duration` (tag `outcome`), `vaadin.errors` (tag `exception`).
- **RPC (server-side)** — `vaadin.rpc.duration` (tags `type`, `outcome`) **plus `vaadin.rpc` spans**, via `RpcInvocationListener` (vaadin/flow#24499). Replaces the prototype's browser-XHR approximation.
- **Tracing** — observation-based; `TracingExecutor` propagates context across `UI.access(...)`; `ObservabilityKit` provisions an `ObservationRegistry` + default meter handler when tracing is enabled.
- **Client (browser→server)** — `vaadin.client.{bootstrap.duration,navigation.duration,web_vitals.lcp,web_vitals.fcp,errors}` with per-session rate limiting; client-side RPC timing removed (now server-side).

## Notes
- Requires Flow `25.3-SNAPSHOT` (contains the merged #24498 + #24499 SPIs).
- Cardinality-guarded: RPC/route/client tags never carry raw names, node ids, or paths/fragments.
- Two latent prototype issues were fixed in passing (route tag length-cap ordering; client-only config not registering the UI listener).
- `mvn verify` green — 104 unit tests, including the client subsystem (untested in the prototype).

## Out of scope
Spring / Spring Boot integration (Parts 3–4).