### PR TITLE
feat: plain Spring integration (observability-kit-spring)

### DIFF
--- a/observability-kit-spring/pom.xml
+++ b/observability-kit-spring/pom.xml
@@ -42,8 +42,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/observability-kit-spring/pom.xml
+++ b/observability-kit-spring/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>${servlet.api.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/observability-kit-spring/pom.xml
+++ b/observability-kit-spring/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>observability-kit</artifactId>
+        <version>5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>observability-kit-spring</artifactId>
+    <packaging>jar</packaging>
+    <name>Observability Kit :: Spring</name>
+    <description>Plain (non-Boot) Spring integration for Observability Kit.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>observability-kit-micrometer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
+++ b/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.spring;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.observability.micrometer.MetricsServiceInitListener;
+import com.vaadin.observability.micrometer.ObservabilitySettings;
+
+/**
+ * Plain-Spring (non-Boot) configuration for Observability Kit.
+ * <p>
+ * Users opt in by importing this class:
+ *
+ * <pre>
+ * {@code
+ * &#64;Configuration
+ * &#64;Import(ObservabilityConfiguration.class)
+ * public class MyAppConfig { ... }
+ * }
+ * </pre>
+ *
+ * Requires a {@link MeterRegistry} bean to be defined elsewhere in the
+ * application context. An {@link ObservationRegistry} bean is picked up if
+ * present (Spring Boot Actuator supplies one); otherwise the Observation code
+ * paths are skipped and traces aren't emitted.
+ */
+@Configuration
+public class ObservabilityConfiguration {
+
+    /**
+     * Builds an {@link ObservabilitySettings} bean from
+     * {@code vaadin.observability.*} properties. All properties are optional
+     * and fall back to sensible defaults.
+     *
+     * @param sessions
+     *            whether to track session metrics (default {@code true})
+     * @param uis
+     *            whether to track UI metrics (default {@code true})
+     * @param navigation
+     *            whether to track navigation metrics (default {@code true})
+     * @param requests
+     *            whether to track request metrics (default {@code true})
+     * @param errors
+     *            whether to track error metrics (default {@code true})
+     * @param traces
+     *            whether to emit traces (default {@code true})
+     * @param tracesSessionId
+     *            whether to include session ID in traces (default
+     *            {@code false})
+     * @param routeCardinalityLimit
+     *            maximum number of distinct route tag values (default
+     *            {@code 200})
+     * @param client
+     *            whether to track client-side metrics (default {@code true})
+     * @param clientRatePerSession
+     *            maximum client-side metric events per session (default
+     *            {@code 100})
+     * @return the configured {@link ObservabilitySettings}
+     */
+    @Bean
+    public ObservabilitySettings observabilitySettings(
+            @Value("${vaadin.observability.sessions:true}") boolean sessions,
+            @Value("${vaadin.observability.uis:true}") boolean uis,
+            @Value("${vaadin.observability.navigation:true}") boolean navigation,
+            @Value("${vaadin.observability.requests:true}") boolean requests,
+            @Value("${vaadin.observability.errors:true}") boolean errors,
+            @Value("${vaadin.observability.traces:true}") boolean traces,
+            @Value("${vaadin.observability.traces.session-id:false}") boolean tracesSessionId,
+            @Value("${vaadin.observability.route-cardinality-limit:200}") int routeCardinalityLimit,
+            @Value("${vaadin.observability.client:true}") boolean client,
+            @Value("${vaadin.observability.client-rate-per-session:100}") int clientRatePerSession) {
+        return ObservabilitySettings.builder().sessions(sessions).uis(uis)
+                .navigation(navigation).requests(requests).errors(errors)
+                .traces(traces).tracesSessionId(tracesSessionId)
+                .routeCardinalityLimit(routeCardinalityLimit).client(client)
+                .clientRatePerSession(clientRatePerSession).build();
+    }
+
+    /**
+     * Creates the {@link MetricsServiceInitListener} bean that wires
+     * instrumentation into the Vaadin service.
+     *
+     * @param registry
+     *            the Micrometer meter registry, must be present in the context
+     * @param observationRegistry
+     *            optional Micrometer observation registry; picked up if a bean
+     *            is present
+     * @param settings
+     *            the observability settings bean
+     * @return a Spring-aware {@link MetricsServiceInitListener}
+     */
+    @Bean
+    public MetricsServiceInitListener metricsServiceInitListener(
+            MeterRegistry registry,
+            ObjectProvider<ObservationRegistry> observationRegistry,
+            ObservabilitySettings settings) {
+        return new SpringMetricsServiceInitListener(registry,
+                observationRegistry.getIfAvailable(), settings);
+    }
+
+    /**
+     * Spring-aware subclass that skips the default Observation handler
+     * registration: in Spring/Boot setups the framework already registers a
+     * {@code DefaultMeterObservationHandler} on the shared
+     * {@link ObservationRegistry} (via Boot's
+     * {@code ObservationAutoConfiguration} or the user's own
+     * {@code @Configuration}), so re-registering here would double-emit Timers.
+     * It also delegates HTTP observation enrichment to
+     * {@link SpringHttpObservationEnricher}.
+     */
+    static class SpringMetricsServiceInitListener
+            extends MetricsServiceInitListener {
+
+        SpringMetricsServiceInitListener(MeterRegistry registry,
+                ObservationRegistry observationRegistry,
+                ObservabilitySettings settings) {
+            super(registry, observationRegistry, settings);
+        }
+
+        @Override
+        protected void installDefaultObservationHandlers(
+                ObservationRegistry observationRegistry,
+                MeterRegistry registry) {
+            // No-op: Spring Boot Actuator's ObservationAutoConfiguration
+            // registers DefaultMeterObservationHandler; re-registering would
+            // double-emit Timers.
+        }
+
+        @Override
+        protected void enrichHttpObservation(VaadinRequest request,
+                String type) {
+            SpringHttpObservationEnricher.enrich(request, type);
+        }
+    }
+}

--- a/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
+++ b/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
@@ -71,7 +71,7 @@ public class ObservabilityConfiguration {
      *            maximum client-side metric events per session (default
      *            {@code 100})
      */
-    public ObservabilityConfiguration(
+    ObservabilityConfiguration(
             @Value("${vaadin.observability.sessions:true}") boolean sessions,
             @Value("${vaadin.observability.uis:true}") boolean uis,
             @Value("${vaadin.observability.navigation:true}") boolean navigation,

--- a/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
+++ b/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
@@ -141,8 +141,8 @@ public class ObservabilityConfiguration {
 
         @Override
         protected void enrichHttpObservation(VaadinRequest request,
-                String type) {
-            SpringHttpObservationEnricher.enrich(request, type);
+                String requestType) {
+            SpringHttpObservationEnricher.enrich(request, requestType);
         }
     }
 }

--- a/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
+++ b/observability-kit-spring/src/main/java/com/vaadin/observability/spring/ObservabilityConfiguration.java
@@ -40,10 +40,12 @@ import com.vaadin.observability.micrometer.ObservabilitySettings;
 @Configuration
 public class ObservabilityConfiguration {
 
+    private final ObservabilitySettings settings;
+
     /**
-     * Builds an {@link ObservabilitySettings} bean from
-     * {@code vaadin.observability.*} properties. All properties are optional
-     * and fall back to sensible defaults.
+     * Binds {@code vaadin.observability.*} properties (all optional, each with
+     * a sensible default) and builds the {@link ObservabilitySettings} used by
+     * the instrumentation.
      *
      * @param sessions
      *            whether to track session metrics (default {@code true})
@@ -68,10 +70,8 @@ public class ObservabilityConfiguration {
      * @param clientRatePerSession
      *            maximum client-side metric events per session (default
      *            {@code 100})
-     * @return the configured {@link ObservabilitySettings}
      */
-    @Bean
-    public ObservabilitySettings observabilitySettings(
+    public ObservabilityConfiguration(
             @Value("${vaadin.observability.sessions:true}") boolean sessions,
             @Value("${vaadin.observability.uis:true}") boolean uis,
             @Value("${vaadin.observability.navigation:true}") boolean navigation,
@@ -82,31 +82,39 @@ public class ObservabilityConfiguration {
             @Value("${vaadin.observability.route-cardinality-limit:200}") int routeCardinalityLimit,
             @Value("${vaadin.observability.client:true}") boolean client,
             @Value("${vaadin.observability.client-rate-per-session:100}") int clientRatePerSession) {
-        return ObservabilitySettings.builder().sessions(sessions).uis(uis)
-                .navigation(navigation).requests(requests).errors(errors)
-                .traces(traces).tracesSessionId(tracesSessionId)
+        this.settings = ObservabilitySettings.builder().sessions(sessions)
+                .uis(uis).navigation(navigation).requests(requests)
+                .errors(errors).traces(traces).tracesSessionId(tracesSessionId)
                 .routeCardinalityLimit(routeCardinalityLimit).client(client)
                 .clientRatePerSession(clientRatePerSession).build();
     }
 
     /**
-     * Creates the {@link MetricsServiceInitListener} bean that wires
-     * instrumentation into the Vaadin service.
+     * Exposes the {@link ObservabilitySettings} bound from
+     * {@code vaadin.observability.*} as a bean.
+     *
+     * @return the configured settings
+     */
+    @Bean
+    ObservabilitySettings observabilitySettings() {
+        return settings;
+    }
+
+    /**
+     * Creates the Spring-aware {@link MetricsServiceInitListener} bean that
+     * wires instrumentation into the Vaadin service.
      *
      * @param registry
      *            the Micrometer meter registry, must be present in the context
      * @param observationRegistry
      *            optional Micrometer observation registry; picked up if a bean
      *            is present
-     * @param settings
-     *            the observability settings bean
      * @return a Spring-aware {@link MetricsServiceInitListener}
      */
     @Bean
-    public MetricsServiceInitListener metricsServiceInitListener(
+    MetricsServiceInitListener metricsServiceInitListener(
             MeterRegistry registry,
-            ObjectProvider<ObservationRegistry> observationRegistry,
-            ObservabilitySettings settings) {
+            ObjectProvider<ObservationRegistry> observationRegistry) {
         return new SpringMetricsServiceInitListener(registry,
                 observationRegistry.getIfAvailable(), settings);
     }

--- a/observability-kit-spring/src/main/java/com/vaadin/observability/spring/SpringHttpObservationEnricher.java
+++ b/observability-kit-spring/src/main/java/com/vaadin/observability/spring/SpringHttpObservationEnricher.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.spring;
+
+import org.springframework.http.server.observation.ServerRequestObservationContext;
+import org.springframework.web.filter.ServerHttpObservationFilter;
+
+import com.vaadin.flow.server.VaadinRequest;
+
+/**
+ * Lifts Vaadin request information into Spring's HTTP server observation (the
+ * {@code http <method> <uri>} span emitted by
+ * {@link ServerHttpObservationFilter}). This makes the parent HTTP span render
+ * as e.g. {@code http post /vaadin/uidl} instead of the generic
+ * {@code http post /**} so the request type is visible in the trace UI without
+ * having to drill into the child {@code vaadin.request.<type>} span.
+ * <p>
+ * Lives in {@code observability-kit-spring} (rather than the framework-agnostic
+ * base module) so Spring's HTTP observation classes can be imported directly
+ * and we don't need reflection.
+ */
+public final class SpringHttpObservationEnricher {
+
+    private SpringHttpObservationEnricher() {
+    }
+
+    /**
+     * Enriches the Spring HTTP observation attached to {@code request}, if any.
+     * Best-effort: silently no-ops if Spring's filter didn't run (e.g.
+     * non-Spring-MVC deployment) or the request isn't a servlet request.
+     *
+     * @param request
+     *            the current Vaadin request, may be {@code null}
+     * @param type
+     *            the classified request type (e.g. {@code uidl}), may be
+     *            {@code null}
+     */
+    public static void enrich(VaadinRequest request, String type) {
+        if (request == null || type == null) {
+            return;
+        }
+        Object ctx = request.getAttribute(
+                ServerHttpObservationFilter.CURRENT_OBSERVATION_CONTEXT_ATTRIBUTE);
+        if (!(ctx instanceof ServerRequestObservationContext src)) {
+            return;
+        }
+        try {
+            src.setPathPattern("/vaadin/" + type);
+            String method = request.getMethod();
+            src.setContextualName(
+                    "http " + (method == null ? "?" : method.toLowerCase())
+                            + " vaadin " + type);
+        } catch (RuntimeException ignored) {
+            // best-effort
+        }
+    }
+}

--- a/observability-kit-spring/src/main/java/com/vaadin/observability/spring/SpringHttpObservationEnricher.java
+++ b/observability-kit-spring/src/main/java/com/vaadin/observability/spring/SpringHttpObservationEnricher.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.server.VaadinRequest;
  * base module) so Spring's HTTP observation classes can be imported directly
  * and we don't need reflection.
  */
-public final class SpringHttpObservationEnricher {
+final class SpringHttpObservationEnricher {
 
     private SpringHttpObservationEnricher() {
     }
@@ -41,7 +41,7 @@ public final class SpringHttpObservationEnricher {
      *            the classified request type (e.g. {@code uidl}), may be
      *            {@code null}
      */
-    public static void enrich(VaadinRequest request, String type) {
+    static void enrich(VaadinRequest request, String type) {
         if (request == null || type == null) {
             return;
         }

--- a/observability-kit-spring/src/test/java/com/vaadin/observability/spring/ObservabilityConfigurationTest.java
+++ b/observability-kit-spring/src/test/java/com/vaadin/observability/spring/ObservabilityConfigurationTest.java
@@ -51,6 +51,8 @@ class ObservabilityConfigurationTest {
             Assertions.assertTrue(settings.isRequests());
             Assertions.assertTrue(settings.isErrors());
             Assertions.assertTrue(settings.isClient());
+            Assertions.assertTrue(settings.isTraces());
+            Assertions.assertFalse(settings.isTracesSessionId());
             Assertions.assertEquals(200, settings.getRouteCardinalityLimit());
             Assertions.assertEquals(100, settings.getClientRatePerSession());
 

--- a/observability-kit-spring/src/test/java/com/vaadin/observability/spring/ObservabilityConfigurationTest.java
+++ b/observability-kit-spring/src/test/java/com/vaadin/observability/spring/ObservabilityConfigurationTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.spring;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockPropertySource;
+
+import com.vaadin.observability.micrometer.MetricsServiceInitListener;
+import com.vaadin.observability.micrometer.ObservabilitySettings;
+
+class ObservabilityConfigurationTest {
+
+    @Configuration
+    @Import(ObservabilityConfiguration.class)
+    static class TestConfig {
+        @Bean
+        MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        static PropertySourcesPlaceholderConfigurer propertyConfigurer() {
+            return new PropertySourcesPlaceholderConfigurer();
+        }
+    }
+
+    @Test
+    void defaultsExposeBindersAndConfig() {
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(
+                TestConfig.class)) {
+            ObservabilitySettings settings = ctx
+                    .getBean(ObservabilitySettings.class);
+            Assertions.assertTrue(settings.isSessions());
+            Assertions.assertTrue(settings.isUis());
+            Assertions.assertTrue(settings.isNavigation());
+            Assertions.assertTrue(settings.isRequests());
+            Assertions.assertTrue(settings.isErrors());
+            Assertions.assertTrue(settings.isClient());
+            Assertions.assertEquals(200, settings.getRouteCardinalityLimit());
+            Assertions.assertEquals(100, settings.getClientRatePerSession());
+
+            Assertions.assertNotNull(
+                    ctx.getBean(MetricsServiceInitListener.class));
+        }
+    }
+
+    @Test
+    void propertyOverridesAreHonored() {
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+            MockPropertySource props = new MockPropertySource()
+                    .withProperty("vaadin.observability.sessions", "false")
+                    .withProperty("vaadin.observability.navigation", "false")
+                    .withProperty(
+                            "vaadin.observability.route-cardinality-limit",
+                            "42");
+            ((ConfigurableEnvironment) ctx.getEnvironment())
+                    .getPropertySources().addFirst(props);
+            ctx.register(TestConfig.class);
+            ctx.refresh();
+
+            ObservabilitySettings settings = ctx
+                    .getBean(ObservabilitySettings.class);
+            Assertions.assertFalse(settings.isSessions());
+            Assertions.assertFalse(settings.isNavigation());
+            Assertions.assertTrue(settings.isUis());
+            Assertions.assertEquals(42, settings.getRouteCardinalityLimit());
+        }
+    }
+
+    @Test
+    void clientPropertyOverridesAreHonored() {
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+            MockPropertySource props = new MockPropertySource()
+                    .withProperty("vaadin.observability.client", "false")
+                    .withProperty(
+                            "vaadin.observability.client-rate-per-session",
+                            "25");
+            ((ConfigurableEnvironment) ctx.getEnvironment())
+                    .getPropertySources().addFirst(props);
+            ctx.register(TestConfig.class);
+            ctx.refresh();
+
+            ObservabilitySettings settings = ctx
+                    .getBean(ObservabilitySettings.class);
+            Assertions.assertFalse(settings.isClient());
+            Assertions.assertEquals(25, settings.getClientRatePerSession());
+        }
+    }
+}

--- a/observability-kit-spring/src/test/java/com/vaadin/observability/spring/ObservabilityConfigurationTest.java
+++ b/observability-kit-spring/src/test/java/com/vaadin/observability/spring/ObservabilityConfigurationTest.java
@@ -10,7 +10,6 @@ package com.vaadin.observability.spring;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +21,8 @@ import org.springframework.mock.env.MockPropertySource;
 
 import com.vaadin.observability.micrometer.MetricsServiceInitListener;
 import com.vaadin.observability.micrometer.ObservabilitySettings;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ObservabilityConfigurationTest {
 
@@ -45,19 +46,19 @@ class ObservabilityConfigurationTest {
                 TestConfig.class)) {
             ObservabilitySettings settings = ctx
                     .getBean(ObservabilitySettings.class);
-            Assertions.assertTrue(settings.isSessions());
-            Assertions.assertTrue(settings.isUis());
-            Assertions.assertTrue(settings.isNavigation());
-            Assertions.assertTrue(settings.isRequests());
-            Assertions.assertTrue(settings.isErrors());
-            Assertions.assertTrue(settings.isClient());
-            Assertions.assertTrue(settings.isTraces());
-            Assertions.assertFalse(settings.isTracesSessionId());
-            Assertions.assertEquals(200, settings.getRouteCardinalityLimit());
-            Assertions.assertEquals(100, settings.getClientRatePerSession());
+            assertThat(settings.isSessions()).isTrue();
+            assertThat(settings.isUis()).isTrue();
+            assertThat(settings.isNavigation()).isTrue();
+            assertThat(settings.isRequests()).isTrue();
+            assertThat(settings.isErrors()).isTrue();
+            assertThat(settings.isClient()).isTrue();
+            assertThat(settings.isTraces()).isTrue();
+            assertThat(settings.isTracesSessionId()).isFalse();
+            assertThat(settings.getRouteCardinalityLimit()).isEqualTo(200);
+            assertThat(settings.getClientRatePerSession()).isEqualTo(100);
 
-            Assertions.assertNotNull(
-                    ctx.getBean(MetricsServiceInitListener.class));
+            assertThat(ctx.getBean(MetricsServiceInitListener.class))
+                    .isNotNull();
         }
     }
 
@@ -77,10 +78,10 @@ class ObservabilityConfigurationTest {
 
             ObservabilitySettings settings = ctx
                     .getBean(ObservabilitySettings.class);
-            Assertions.assertFalse(settings.isSessions());
-            Assertions.assertFalse(settings.isNavigation());
-            Assertions.assertTrue(settings.isUis());
-            Assertions.assertEquals(42, settings.getRouteCardinalityLimit());
+            assertThat(settings.isSessions()).isFalse();
+            assertThat(settings.isNavigation()).isFalse();
+            assertThat(settings.isUis()).isTrue();
+            assertThat(settings.getRouteCardinalityLimit()).isEqualTo(42);
         }
     }
 
@@ -99,8 +100,8 @@ class ObservabilityConfigurationTest {
 
             ObservabilitySettings settings = ctx
                     .getBean(ObservabilitySettings.class);
-            Assertions.assertFalse(settings.isClient());
-            Assertions.assertEquals(25, settings.getClientRatePerSession());
+            assertThat(settings.isClient()).isFalse();
+            assertThat(settings.getClientRatePerSession()).isEqualTo(25);
         }
     }
 }

--- a/observability-kit-spring/src/test/java/com/vaadin/observability/spring/SpringHttpObservationEnricherTest.java
+++ b/observability-kit-spring/src/test/java/com/vaadin/observability/spring/SpringHttpObservationEnricherTest.java
@@ -8,9 +8,13 @@
  */
 package com.vaadin.observability.spring;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.web.filter.ServerHttpObservationFilter;
 
 import com.vaadin.flow.server.VaadinRequest;
@@ -38,5 +42,26 @@ class SpringHttpObservationEnricherTest {
                 .thenReturn(null);
         Assertions.assertDoesNotThrow(
                 () -> SpringHttpObservationEnricher.enrich(request, "uidl"));
+    }
+
+    @Test
+    void enrichmentSetsPathPatternAndContextualName() {
+        HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse httpResponse = Mockito
+                .mock(HttpServletResponse.class);
+        ServerRequestObservationContext context = new ServerRequestObservationContext(
+                httpRequest, httpResponse);
+
+        VaadinRequest request = Mockito.mock(VaadinRequest.class);
+        Mockito.when(request.getMethod()).thenReturn("POST");
+        Mockito.when(request.getAttribute(
+                ServerHttpObservationFilter.CURRENT_OBSERVATION_CONTEXT_ATTRIBUTE))
+                .thenReturn(context);
+
+        SpringHttpObservationEnricher.enrich(request, "uidl");
+
+        Assertions.assertEquals("/vaadin/uidl", context.getPathPattern());
+        Assertions.assertEquals("http post vaadin uidl",
+                context.getContextualName());
     }
 }

--- a/observability-kit-spring/src/test/java/com/vaadin/observability/spring/SpringHttpObservationEnricherTest.java
+++ b/observability-kit-spring/src/test/java/com/vaadin/observability/spring/SpringHttpObservationEnricherTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2026 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.observability.spring;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.filter.ServerHttpObservationFilter;
+
+import com.vaadin.flow.server.VaadinRequest;
+
+class SpringHttpObservationEnricherTest {
+
+    @Test
+    void nullRequestDoesNotThrow() {
+        Assertions.assertDoesNotThrow(
+                () -> SpringHttpObservationEnricher.enrich(null, "uidl"));
+    }
+
+    @Test
+    void nullTypeDoesNotThrow() {
+        VaadinRequest request = Mockito.mock(VaadinRequest.class);
+        Assertions.assertDoesNotThrow(
+                () -> SpringHttpObservationEnricher.enrich(request, null));
+    }
+
+    @Test
+    void missingObservationContextDoesNotThrow() {
+        VaadinRequest request = Mockito.mock(VaadinRequest.class);
+        Mockito.when(request.getAttribute(
+                ServerHttpObservationFilter.CURRENT_OBSERVATION_CONTEXT_ATTRIBUTE))
+                .thenReturn(null);
+        Assertions.assertDoesNotThrow(
+                () -> SpringHttpObservationEnricher.enrich(request, "uidl"));
+    }
+}

--- a/observability-kit-spring/src/test/java/com/vaadin/observability/spring/SpringHttpObservationEnricherTest.java
+++ b/observability-kit-spring/src/test/java/com/vaadin/observability/spring/SpringHttpObservationEnricherTest.java
@@ -11,57 +11,61 @@ package com.vaadin.observability.spring;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.web.filter.ServerHttpObservationFilter;
 
 import com.vaadin.flow.server.VaadinRequest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class SpringHttpObservationEnricherTest {
 
     @Test
     void nullRequestDoesNotThrow() {
-        Assertions.assertDoesNotThrow(
-                () -> SpringHttpObservationEnricher.enrich(null, "uidl"));
+        assertThatCode(() -> SpringHttpObservationEnricher.enrich(null, "uidl"))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    void nullTypeDoesNotThrow() {
-        VaadinRequest request = Mockito.mock(VaadinRequest.class);
-        Assertions.assertDoesNotThrow(
-                () -> SpringHttpObservationEnricher.enrich(request, null));
+    void nullTypeDoesNotThrow(@Mock VaadinRequest request) {
+        assertThatCode(
+                () -> SpringHttpObservationEnricher.enrich(request, null))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    void missingObservationContextDoesNotThrow() {
-        VaadinRequest request = Mockito.mock(VaadinRequest.class);
-        Mockito.when(request.getAttribute(
+    void missingObservationContextDoesNotThrow(@Mock VaadinRequest request) {
+        when(request.getAttribute(
                 ServerHttpObservationFilter.CURRENT_OBSERVATION_CONTEXT_ATTRIBUTE))
                 .thenReturn(null);
-        Assertions.assertDoesNotThrow(
-                () -> SpringHttpObservationEnricher.enrich(request, "uidl"));
+        assertThatCode(
+                () -> SpringHttpObservationEnricher.enrich(request, "uidl"))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    void enrichmentSetsPathPatternAndContextualName() {
-        HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
-        HttpServletResponse httpResponse = Mockito
-                .mock(HttpServletResponse.class);
+    void enrichmentSetsPathPatternAndContextualName(@Mock VaadinRequest request,
+            @Mock HttpServletRequest httpRequest,
+            @Mock HttpServletResponse httpResponse) {
         ServerRequestObservationContext context = new ServerRequestObservationContext(
                 httpRequest, httpResponse);
 
-        VaadinRequest request = Mockito.mock(VaadinRequest.class);
-        Mockito.when(request.getMethod()).thenReturn("POST");
-        Mockito.when(request.getAttribute(
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getAttribute(
                 ServerHttpObservationFilter.CURRENT_OBSERVATION_CONTEXT_ATTRIBUTE))
                 .thenReturn(context);
 
         SpringHttpObservationEnricher.enrich(request, "uidl");
 
-        Assertions.assertEquals("/vaadin/uidl", context.getPathPattern());
-        Assertions.assertEquals("http post vaadin uidl",
-                context.getContextualName());
+        assertThat(context.getPathPattern()).isEqualTo("/vaadin/uidl");
+        assertThat(context.getContextualName())
+                .isEqualTo("http post vaadin uidl");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
     <modules>
         <module>observability-kit-micrometer</module>
+        <module>observability-kit-spring</module>
     </modules>
 
     <properties>
@@ -34,6 +35,7 @@
         <servlet.api.version>6.1.0</servlet.api.version>
         <junit.version>5.11.4</junit.version>
         <mockito.version>5.20.0</mockito.version>
+        <spring.boot.version>4.0.5</spring.boot.version>
         <vaadin.license.checker.version>3.0.1</vaadin.license.checker.version>
 
         <maven.compiler.release>21</maven.compiler.release>
@@ -106,6 +108,13 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
                 <version>${vaadin.license.checker.version}</version>


### PR DESCRIPTION
Closes #327.

Adds the `observability-kit-spring` module — plain (non-Boot) Spring integration, opt-in via `@Import(ObservabilityConfiguration.class)`.

## What's included
- **`ObservabilityConfiguration`** (`@Configuration`): binds `vaadin.observability.*` via constructor injection into an `ObservabilitySettings`, and exposes a `MetricsServiceInitListener` bean. Uses a Spring-aware listener subclass that:
  - **skips** default observation-handler registration (Spring/Boot already registers a `DefaultMeterObservationHandler` — avoids double Timer emission), and
  - **enriches** Spring's HTTP server-request observation (`/vaadin/<type>`, `http <method> vaadin <type>`) so the request type is visible on the parent HTTP span.
- **`SpringHttpObservationEnricher`**: best-effort lift of the Vaadin request type into Spring's `ServerRequestObservationContext`; no-ops without spring-web.
- Reuses the core listener's `installDefaultObservationHandlers` / `enrichHttpObservation` hooks (added in Part 2).

## Notes
- **Non-Boot on purpose**: properties are bound with `@Value` constructor injection, not `@ConfigurationProperties` (that's a Spring Boot feature — it arrives with the starter in Part 4). No Spring Boot dependency here.
- **Minimal public surface**: only `ObservabilityConfiguration` is `public` (required so users can `@Import` it); its constructor, both `@Bean` methods, the enricher, and the listener subclass are all package-private.
- Exposes the full settings surface incl. `client` / `client-rate-per-session` (the prototype omitted these).
- Tests use AssertJ + the Mockito JUnit 5 extension; `mvn verify` green (7 module tests; 111 across the reactor).

## Dependencies
- `vaadin-spring` (flow-bom), `spring-context`, `spring-web` (optional); Spring Boot `4.0.5` BOM for `spring-*` version management; `assertj-core` + `mockito-junit-jupiter` (test).

## Out of scope
Spring Boot auto-configuration / starter + integration-test modules (Part 4, #328).