### PR TITLE
feat: for spans record event and component

### DIFF
--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
@@ -8,11 +8,18 @@
  */
 package com.vaadin.observability.micrometer;
 
+import java.util.Optional;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.server.communication.RpcInvocationEvent;
 import com.vaadin.flow.server.communication.RpcInvocationListener;
 import com.vaadin.observability.micrometer.trace.ObservationNames;
@@ -33,9 +40,16 @@ import com.vaadin.observability.micrometer.trace.ObservationNames;
  * unavailable), the binder falls back to recording the Timer directly.</li>
  * </ul>
  * <p>
- * Tags: {@code type} (RPC invocation type) and {@code outcome}
- * ({@code success}/{@code error}). The invocation name and node ID are
- * deliberately omitted because they are high-cardinality.
+ * Timer tags (low cardinality): {@code type} (RPC invocation type) and
+ * {@code outcome} ({@code success}/{@code error}). The invocation name and node
+ * ID are deliberately omitted from the Timer tags because they are
+ * high-cardinality.
+ * <p>
+ * When tracing is enabled, the span additionally carries the invocation name
+ * ({@link ObservationNames#KEY_EVENT_NAME}) and the targeted component class
+ * ({@link ObservationNames#KEY_COMPONENT}) as high-cardinality key-values.
+ * These attach to the span only and never become Timer tags, so they enrich
+ * traces without affecting metric cardinality.
  */
 final class RpcMetricsBinder implements RpcInvocationListener {
 
@@ -79,11 +93,57 @@ final class RpcMetricsBinder implements RpcInvocationListener {
                     .createNotStarted(MeterNames.RPC_DURATION,
                             observationRegistry)
                     .contextualName(ObservationNames.RPC + "." + type)
-                    .lowCardinalityKeyValue(MeterNames.TAG_TYPE, type).start();
+                    .lowCardinalityKeyValue(MeterNames.TAG_TYPE, type);
+
+            // Span-only enrichment: the invocation name (e.g. the DOM event
+            // name) and the targeted component class. Added as high-cardinality
+            // key-values so they never leak into the Timer tags.
+            String name = event.getName();
+            if (name != null) {
+                obs.highCardinalityKeyValue(ObservationNames.KEY_EVENT_NAME,
+                        name);
+            }
+            resolveComponentType(event)
+                    .ifPresent(component -> obs.highCardinalityKeyValue(
+                            ObservationNames.KEY_COMPONENT, component));
+
+            obs.start();
             observation.set(obs);
             observationScope.set(obs.openScope());
         } else {
             sample.set(Timer.start(registry));
+        }
+    }
+
+    /**
+     * Resolves the class name of the {@link Component} the invocation targets,
+     * by looking up the target {@code StateNode} in the UI's state tree and
+     * walking up to the nearest enclosing component. Returns
+     * {@link Optional#empty()} if the invocation does not target a node, the
+     * node is no longer attached, or no component can be resolved.
+     */
+    private static Optional<String> resolveComponentType(
+            RpcInvocationEvent event) {
+        int nodeId = event.getNodeId();
+        if (nodeId < 0) {
+            return Optional.empty();
+        }
+        UI ui = event.getUI();
+        if (ui == null) {
+            return Optional.empty();
+        }
+        try {
+            StateTree tree = ui.getInternals().getStateTree();
+            StateNode node = tree.getNodeById(nodeId);
+            if (node == null) {
+                return Optional.empty();
+            }
+            return Element.get(node).getComponent()
+                    .map(component -> component.getClass().getName());
+        } catch (RuntimeException e) {
+            // Resolution is best-effort enrichment; never let it break the
+            // invocation or the surrounding span.
+            return Optional.empty();
         }
     }
 

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/RpcMetricsBinder.java
@@ -16,6 +16,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.StateNode;
@@ -138,7 +139,7 @@ final class RpcMetricsBinder implements RpcInvocationListener {
             if (node == null) {
                 return Optional.empty();
             }
-            return Element.get(node).getComponent()
+            return ComponentUtil.findParentComponent(Element.get(node))
                     .map(component -> component.getClass().getName());
         } catch (RuntimeException e) {
             // Resolution is best-effort enrichment; never let it break the

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
@@ -60,6 +60,21 @@ public final class ObservationNames {
     /** Observation/span name for a server-side RPC invocation. */
     public static final String RPC = "vaadin.rpc";
 
+    /**
+     * High-cardinality span attribute: the human-readable invocation name (DOM
+     * event name, invoked method name, navigation location, ...). Span-only; it
+     * is never added as a Timer tag because of its cardinality.
+     */
+    public static final String KEY_EVENT_NAME = "vaadin.rpc.event_name";
+
+    /**
+     * High-cardinality span attribute: the class name of the Vaadin
+     * {@code Component} that the invocation targets, when it can be resolved
+     * from the target node. Span-only; it is never added as a Timer tag because
+     * of its cardinality.
+     */
+    public static final String KEY_COMPONENT = "vaadin.rpc.component";
+
     private ObservationNames() {
     }
 }

--- a/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
+++ b/observability-kit-micrometer/src/main/java/com/vaadin/observability/micrometer/trace/ObservationNames.java
@@ -87,7 +87,7 @@ public final class ObservationNames {
      * event name, invoked method name, navigation location, ...). Span-only; it
      * is never added as a Timer tag because of its cardinality.
      */
-    public static final String KEY_EVENT_NAME = "vaadin.rpc.event_name";
+    public static final String KEY_EVENT_NAME = "vaadin.rpc.event";
 
     /**
      * High-cardinality span attribute: the class name of the Vaadin

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
@@ -25,6 +25,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.server.communication.RpcInvocationEvent;
 import com.vaadin.observability.micrometer.trace.ObservationNames;
 
@@ -35,6 +39,7 @@ class RpcMetricsBinderTest {
 
         final List<String> names = new ArrayList<>();
         final List<Map<String, String>> tags = new ArrayList<>();
+        final List<Map<String, String>> highCardinalityTags = new ArrayList<>();
         final AtomicBoolean errored = new AtomicBoolean();
         Observation.Context lastContext;
 
@@ -47,6 +52,11 @@ class RpcMetricsBinderTest {
                 snap.put(kv.getKey(), kv.getValue());
             }
             tags.add(snap);
+            Map<String, String> highSnap = new HashMap<>();
+            for (KeyValue kv : ctx.getHighCardinalityKeyValues()) {
+                highSnap.put(kv.getKey(), kv.getValue());
+            }
+            highCardinalityTags.add(highSnap);
             if (ctx.getError() != null) {
                 errored.set(true);
             }
@@ -233,5 +243,140 @@ class RpcMetricsBinderTest {
                 "second invocation should record success outcome");
         Assertions.assertEquals(1L, successTimer.count(),
                 "error state must not bleed into next invocation");
+    }
+
+    @Test
+    void observationPathAddsEventNameAsHighCardinalitySpanAttribute() {
+        SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        observationRegistry.observationConfig()
+                .observationHandler(
+                        new DefaultMeterObservationHandler(simpleRegistry))
+                .observationHandler(recorder);
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(simpleRegistry,
+                observationRegistry,
+                ObservabilitySettings.builder().traces(true).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+        Mockito.when(event.getName()).thenReturn("click");
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Assertions.assertEquals("click",
+                recorder.highCardinalityTags.get(0)
+                        .get(ObservationNames.KEY_EVENT_NAME),
+                "span should carry the invocation name as a high-cardinality attribute");
+
+        // The event name must not leak into the Timer tags.
+        Assertions.assertFalse(
+                recorder.tags.get(0)
+                        .containsKey(ObservationNames.KEY_EVENT_NAME),
+                "event name must not be a low-cardinality Timer tag");
+        Timer timer = simpleRegistry.find(MeterNames.RPC_DURATION)
+                .tag(MeterNames.TAG_TYPE, "event")
+                .tag(MeterNames.TAG_OUTCOME, MeterNames.OUTCOME_SUCCESS)
+                .timer();
+        Assertions.assertNotNull(timer,
+                "Timer tags should remain type + outcome only");
+        Assertions.assertEquals(1L, timer.count());
+    }
+
+    @Test
+    void observationPathOmitsEventNameWhenNull() {
+        SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        observationRegistry.observationConfig()
+                .observationHandler(
+                        new DefaultMeterObservationHandler(simpleRegistry))
+                .observationHandler(recorder);
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(simpleRegistry,
+                observationRegistry,
+                ObservabilitySettings.builder().traces(true).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+        Mockito.when(event.getName()).thenReturn(null);
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Assertions.assertFalse(
+                recorder.highCardinalityTags.get(0)
+                        .containsKey(ObservationNames.KEY_EVENT_NAME),
+                "no event name attribute should be added when getName() is null");
+    }
+
+    @Test
+    void observationPathAddsComponentClassWhenNodeResolves() {
+        SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        observationRegistry.observationConfig()
+                .observationHandler(
+                        new DefaultMeterObservationHandler(simpleRegistry))
+                .observationHandler(recorder);
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(simpleRegistry,
+                observationRegistry,
+                ObservabilitySettings.builder().traces(true).build());
+
+        // Build a real UI with an attached component so the binder can resolve
+        // the component class from the target node id.
+        UI ui = new UI();
+        Element element = ElementFactory.createDiv();
+        Component component = new Component(element) {
+        };
+        ui.getElement().appendChild(element);
+        int nodeId = element.getNode().getId();
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+        Mockito.when(event.getUI()).thenReturn(ui);
+        Mockito.when(event.getNodeId()).thenReturn(nodeId);
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Assertions.assertEquals(component.getClass().getName(),
+                recorder.highCardinalityTags.get(0)
+                        .get(ObservationNames.KEY_COMPONENT),
+                "span should carry the targeted component class as a high-cardinality attribute");
+        Assertions.assertFalse(
+                recorder.tags.get(0)
+                        .containsKey(ObservationNames.KEY_COMPONENT),
+                "component class must not be a low-cardinality Timer tag");
+    }
+
+    @Test
+    void observationPathOmitsComponentWhenNodeIdNegative() {
+        SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        observationRegistry.observationConfig()
+                .observationHandler(
+                        new DefaultMeterObservationHandler(simpleRegistry))
+                .observationHandler(recorder);
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(simpleRegistry,
+                observationRegistry,
+                ObservabilitySettings.builder().traces(true).build());
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+        Mockito.when(event.getNodeId()).thenReturn(-1);
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Assertions.assertFalse(
+                recorder.highCardinalityTags.get(0)
+                        .containsKey(ObservationNames.KEY_COMPONENT),
+                "no component attribute should be added when the invocation targets no node");
     }
 }

--- a/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
+++ b/observability-kit-micrometer/src/test/java/com/vaadin/observability/micrometer/RpcMetricsBinderTest.java
@@ -354,6 +354,46 @@ class RpcMetricsBinderTest {
     }
 
     @Test
+    void observationPathResolvesEnclosingComponentForSubElement() {
+        SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        RecordingHandler recorder = new RecordingHandler();
+        observationRegistry.observationConfig()
+                .observationHandler(
+                        new DefaultMeterObservationHandler(simpleRegistry))
+                .observationHandler(recorder);
+
+        RpcMetricsBinder binder = new RpcMetricsBinder(simpleRegistry,
+                observationRegistry,
+                ObservabilitySettings.builder().traces(true).build());
+
+        // Build a component whose root has a nested sub-element that is not
+        // itself mapped to a component. An RPC targeting the sub-element must
+        // resolve to the enclosing component by walking up the element tree.
+        UI ui = new UI();
+        Element root = ElementFactory.createDiv();
+        Component component = new Component(root) {
+        };
+        Element subElement = ElementFactory.createSpan();
+        root.appendChild(subElement);
+        ui.getElement().appendChild(root);
+        int nodeId = subElement.getNode().getId();
+
+        RpcInvocationEvent event = Mockito.mock(RpcInvocationEvent.class);
+        Mockito.when(event.getType()).thenReturn("event");
+        Mockito.when(event.getUI()).thenReturn(ui);
+        Mockito.when(event.getNodeId()).thenReturn(nodeId);
+
+        binder.invocationStarted(event);
+        binder.invocationEnded(event);
+
+        Assertions.assertEquals(component.getClass().getName(),
+                recorder.highCardinalityTags.get(0)
+                        .get(ObservationNames.KEY_COMPONENT),
+                "span should resolve the enclosing component for a sub-element target");
+    }
+
+    @Test
     void observationPathOmitsComponentWhenNodeIdNegative() {
         SimpleMeterRegistry simpleRegistry = new SimpleMeterRegistry();
         ObservationRegistry observationRegistry = ObservationRegistry.create();


### PR DESCRIPTION
When running with tracing enabled
eligible spans will contain event
name and component class name if
found for element.
